### PR TITLE
LoadFrom() now uses envy to load environment variables before establi…

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/gobuffalo/envy"
 	"github.com/pkg/errors"
 
 	"github.com/markbates/going/defaults"
@@ -69,6 +70,7 @@ func findConfigPath() (string, error) {
 
 // LoadFrom reads a configuration from the reader and sets up the connections
 func LoadFrom(r io.Reader) error {
+	envy.Load()
 	tmpl := template.New("test")
 	tmpl.Funcs(map[string]interface{}{
 		"envOr": func(s1, s2 string) string {


### PR DESCRIPTION
I had an issue with my environment where the database connection details in my `.env` file were not being consumed by pop's config loading logic.  The simple solution was to use `envy.Load()` before the connections were made.  This allows the environment variables to replace the placeholder tokens in `database.yml`.

The only hang up I have with this solution is the dependency to the envy package.

Example database.yml:
```
development:
  dialect: "mysql"
  database: "mailedit_development"
  host: {{ env "DATABASE_HOST" }}
  port: {{ env "DATABASE_PORT" }}
  user: {{ env "DATABASE_USERNAME" }}
  password: {{ env "DATABASE_PASSWORD" }}
```

Thanks @paganotoni  for the fix suggestion