### PR TITLE
Inner associations Eager Loading

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: pop
 release:
   github:
-    owner: markbates
+    owner: gobuffalo
     name: pop
   name_template: '{{.Tag}}'
 brew:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -87,6 +87,18 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/kr/pretty"
+  packages = ["."]
+  revision = "cfb55aafdaf3ec08f0db22699ab822c50091b1c4"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/kr/text"
+  packages = ["."]
+  revision = "7cafcd837844e784b526369c9bce262804aebc60"
+
+[[projects]]
+  branch = "master"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -242,6 +254,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "32290b8e6ba52818a481f1631d4f2c29dc8f789c3ba6ddfeaa5ba399717825b5"
+  inputs-digest = "9d83caf78f8239c051d5bddebd0d82fdf1e09db1a32d32ca254f6968c5651631"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ sql, args := query.ToSQL(&pop.Model{Value: models.UserRole{}}, "user_roles.*",
 err := models.DB.RawQuery(sql, args...).All(&roles)
 ```
 
-#### Eager Loading
+### Eager Loading
 **pop** allows you to perform an eager loading for associations defined in a model. By using `pop.Connection.Eager()` function plus some fields tags predefined in your model you can extract associated data from a model.
 
 ```go
@@ -279,6 +279,16 @@ type Book struct {
   Isbn    string
   User    User        `belongs_to:"user"`
   UserID  uuid.UUID
+  Writers Writers     `has_many:"writers"`
+}
+```
+
+```go
+type Writer struct {
+   ID     uuid.UUID   `db:"id"`
+   Name   string      `db:"name"``
+   BookID uuid.UUID   `db:"book_id"`
+   Book   Book        `belongs_to:"book"`
 }
 ```
 
@@ -317,6 +327,21 @@ type Addresses []Address
 u := Users{}
 err := tx.Eager().Where("name = 'Mark'").All(&u)  // preload all associations for user with name 'Mark', i.e Books, Houses and FavoriteSong
 err  = tx.Eager("Books").Where("name = 'Mark'").All(&u) // preload only Books association for user with name 'Mark'.
+```
+
+#### Eager Loading Nested Associations
+ pop allows you to eager loading nested associations by using `.` character to concatenate them. Take a look at the example bellow.
+```go
+tx.Eager("Books.User").First(&u)  // will load all Books for u and for every Book will load the user which will be the same as u.
+``` 
+```go
+ tx.Eager("Books.Writers").First(&u)  // will load all Books for u and for every Book will load all Writers.
+```
+```go
+tx.Eager("Books.Writers.Book").First(&u)  // will load all Books for u and for every Book will load all Writers and for every writer will load the Book association.
+```
+```go
+tx.Eager("Books.Writers").Eager("FavoriteSong").First(&u)  // will load all Books for u and for every Book will load all Writers. And Also it will load the favorite song for user.
 ```
 
 #### Callbacks

--- a/config.go
+++ b/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gobuffalo/envy"
 	"github.com/pkg/errors"
 
-	"github.com/markbates/going/defaults"
 	"gopkg.in/yaml.v2"
 )
 
@@ -74,10 +73,10 @@ func LoadFrom(r io.Reader) error {
 	tmpl := template.New("test")
 	tmpl.Funcs(map[string]interface{}{
 		"envOr": func(s1, s2 string) string {
-			return defaults.String(os.Getenv(s1), s2)
+			return envy.Get(s1, s2)
 		},
 		"env": func(s1 string) string {
-			return os.Getenv(s1)
+			return envy.Get(s1, "")
 		},
 	})
 	b, err := ioutil.ReadAll(r)

--- a/config_test.go
+++ b/config_test.go
@@ -11,7 +11,7 @@ func Test_LoadsConnectionsFromConfig(t *testing.T) {
 	r := require.New(t)
 
 	conns := pop.Connections
-	r.Equal(5, len(conns))
+	r.Equal(4, len(conns))
 }
 
 func Test_AddLookupPaths(t *testing.T) {

--- a/database.yml
+++ b/database.yml
@@ -18,10 +18,6 @@ postgres:
   url: "postgres://postgres:postgres@localhost:5432/pop_test?sslmode=disable"
   pool: 25
 
-sqlite:
-  dialect: "sqlite3"
-  database: "./sql_scripts/sqlite/test.sqlite"
-
 cockroach:
   # url: "cockroach://root@127.0.0.1:26257/pop_test?application_name=cockroach&sslmode=disable"
   dialect: "cockroach"
@@ -30,4 +26,8 @@ cockroach:
   port: {{ envOr "COCKROACH_PORT" "26257"  }}
   user: {{ envOr "COCKROACH_USER" "root"  }}
   password: {{ envOr "COCKROACH_PASSWORD" ""  }}
+
+sqlite:
+  dialect: "sqlite3"
+  database: "./sql_scripts/sqlite/test.sqlite"
 

--- a/pop.go
+++ b/pop.go
@@ -8,6 +8,8 @@ import (
 	"github.com/fatih/color"
 )
 
+var AvailableDialects = []string{"postgres", "mysql", "cockroach"}
+
 // Debug mode, to toggle verbose log traces
 var Debug = false
 

--- a/pop_test.go
+++ b/pop_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/kr/pretty"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/suite"
@@ -49,6 +50,7 @@ func init() {
 	dialect := os.Getenv("SODA_DIALECT")
 
 	var err error
+	pretty.Println("### pop.Connections ->", pop.Connections)
 	PDB, err = pop.Connect(dialect)
 	if err != nil {
 		log.Panic(err)

--- a/soda/cmd/generate/attribute_test.go
+++ b/soda/cmd/generate/attribute_test.go
@@ -16,7 +16,7 @@ func Test_Attribute_String(t *testing.T) {
 	}{
 		{
 			name: "user_id",
-			exp:  "\tUserId string `json:\"user_id\" db:\"user_id\"`",
+			exp:  "\tUserID string `json:\"user_id\" db:\"user_id\"`",
 		},
 		{
 			name: "UserID",
@@ -28,11 +28,11 @@ func Test_Attribute_String(t *testing.T) {
 		},
 		{
 			name: "userId",
-			exp:  "\tUserId string `json:\"user_id\" db:\"user_id\"`",
+			exp:  "\tUserID string `json:\"user_id\" db:\"user_id\"`",
 		},
 		{
 			name: "user-id",
-			exp:  "\tUserId string `json:\"user_id\" db:\"user_id\"`",
+			exp:  "\tUserID string `json:\"user_id\" db:\"user_id\"`",
 		},
 	}
 

--- a/soda/cmd/generate/config_cmd.go
+++ b/soda/cmd/generate/config_cmd.go
@@ -1,18 +1,20 @@
 package generate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/gobuffalo/makr"
+	"github.com/gobuffalo/pop"
 	"github.com/markbates/going/defaults"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	ConfigCmd.Flags().StringVarP(&dialect, "type", "t", "postgres", "What type of database do you want to use? (postgres, mysql, sqlite3, cockroach)")
+	ConfigCmd.Flags().StringVarP(&dialect, "type", "t", "postgres", fmt.Sprintf("What type of database do you want to use? (%s)", strings.Join(pop.AvailableDialects, ", ")))
 }
 
 var dialect string

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -179,7 +179,7 @@ func (m model) Fizz() string {
 func newModel(name string) model {
 	m := model{
 		Package: "models",
-		Imports: []string{"time", "github.com/gobuffalo/pop", "github.com/markbates/validate"},
+		Imports: []string{"time", "github.com/gobuffalo/pop", "github.com/gobuffalo/validate"},
 		Name:    inflect.Name(name),
 		Attributes: []attribute{
 			{Name: inflect.Name("created_at"), OriginalType: "time.Time", GoType: "time.Time"},

--- a/soda/cmd/version.go
+++ b/soda/cmd/version.go
@@ -1,3 +1,3 @@
 package cmd
 
-const Version = "v4.0.1"
+const Version = "v4.0.2"

--- a/soda/cmd/version.go
+++ b/soda/cmd/version.go
@@ -1,3 +1,3 @@
 package cmd
 
-const Version = "v4.0.0"
+const Version = "v4.0.1"

--- a/soda/cmd/version.go
+++ b/soda/cmd/version.go
@@ -1,3 +1,3 @@
 package cmd
 
-const Version = "v4.0.2"
+const Version = "v4.0.3"

--- a/soda/cmd/version.go
+++ b/soda/cmd/version.go
@@ -1,3 +1,3 @@
 package cmd
 
-const Version = "v4.0.4"
+const Version = "v4.0.5"

--- a/soda/cmd/version.go
+++ b/soda/cmd/version.go
@@ -1,3 +1,3 @@
 package cmd
 
-const Version = "v4.0.3"
+const Version = "v4.0.4"

--- a/sqlite.go
+++ b/sqlite.go
@@ -1,4 +1,4 @@
-// +build sqlite !appengine !appenginevm
+// +build sqlite
 
 package pop
 
@@ -20,6 +20,10 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	AvailableDialects = append(AvailableDialects, "sqlite3")
+}
 
 var _ dialect = &sqlite{}
 

--- a/sqlite_shim.go
+++ b/sqlite_shim.go
@@ -1,9 +1,15 @@
-// +build appengine appenginevm
 // +build !sqlite
 
 package pop
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("in shim")
+}
 
 func newSQLite(deets *ConnectionDetails) (dialect, error) {
 	return nil, errors.New("sqlite3 was not compiled into the binary")

--- a/sqlite_shim.go
+++ b/sqlite_shim.go
@@ -4,12 +4,7 @@ package pop
 
 import (
 	"errors"
-	"fmt"
 )
-
-func init() {
-	fmt.Println("in shim")
-}
 
 func newSQLite(deets *ConnectionDetails) (dialect, error) {
 	return nil, errors.New("sqlite3 was not compiled into the binary")

--- a/test.sh
+++ b/test.sh
@@ -23,13 +23,13 @@ function test {
   ./tsoda drop -e $SODA_DIALECT -c ./database.yml
   ./tsoda create -e $SODA_DIALECT -c ./database.yml
   ./tsoda migrate -e $SODA_DIALECT -c ./database.yml
-  go test $(go list ./... | grep -v /vendor/)
+  go test -tags sqlite $verbose $(go list ./... | grep -v /vendor/)
 }
 
-test "sqlite"
 test "postgres"
 test "cockroach"
 test "mysql"
+test "sqlite"
 
 docker-compose down
 


### PR DESCRIPTION
@markbates I just worked on eager loading nested associations. 

The overall idea is  adding to pop the ability to eager loading nested associations. To give you an example of how it would be used, take a look at the code below:

```go
type User struct {
    ID           uuid.UUID   `db:"id"` 
    FavoriteSong Song        `has_one:"song"`
    Books        Books       `has_many:"books"`
}

type Song struct {
    ID          uuid.UUID    `db:"id"`
    UserID      uuid.UUID    `db:"user_id"`
    Title       string       `db:"title"`
}

type Book struct {
   ID       uuid.UUID  `db:"id"`
   UserID   uuid.UUID  `db:"user_id"`
   User     User       `belongs_to:"user"`
   Writers  Writers    `has_many:"writers"`
}

type Writer struct {
   ID     uuid.UUID   `db:"id"`
   Name   string      `db:"name"``
   BookID uuid.UUID   `db:"book_id"`
   Book   Book        `belongs_to:"book"`
}
```

With the above Models we can now perform any of these eager loading queries:

```go
   tx.Eager("FavoriteSong").First(&u)  // will load only FavoriteSong for u.
```
```go
   tx.Eager("Books.User").First(&u)  // will load all Books for u and for every Book will load the user which will be the same as u.
```
```go
   tx.Eager("Books.Writers").First(&u)  // will load all Books for u and for every Book will load all Writers.
```
```go
   tx.Eager("Books.Writers.Book").First(&u)  // will load all Books for u and for every Book will load all Writers and for every writer will load the Book association.
```
```go
   tx.Eager("Books.Writers").
      Eager("FavoriteSong").First(&u)  // will load all Books for u and for every Book will load all Writers. And Also it will load the favorite song for user.
```
The chain can go on and on, as long as the expression is valid. Let me know your thoughts.