### PR TITLE
preserve user specific URL options while 'db create' and 'db drop'.

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -37,6 +37,11 @@ func (m *mysql) URL() string {
 
 func (m *mysql) urlWithoutDb() string {
 	c := m.ConnectionDetails
+	if m.ConnectionDetails.URL != "" {
+		// respect user's own URL definition (with options).
+		url := strings.TrimPrefix(m.ConnectionDetails.URL, "mysql://")
+		return strings.Replace(url, "/"+c.Database+"?", "/?", 1)
+	}
 	s := "%s:%s@(%s:%s)/?parseTime=true&multiStatements=true&readTimeout=1s"
 	return fmt.Sprintf(s, c.User, c.Password, c.Host, c.Port)
 }

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -1,0 +1,21 @@
+package pop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MySQL_URL(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		URL: "mysql://dbase:dbase@(dbase:dbase)/dbase?dbase=dbase",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+
+	m := &mysql{ConnectionDetails: cd}
+	r.Equal("dbase:dbase@(dbase:dbase)/dbase?dbase=dbase", m.URL())
+	r.Equal("dbase:dbase@(dbase:dbase)/?dbase=dbase", m.urlWithoutDb())
+}


### PR DESCRIPTION
Preserve user specific URL options while running `buffalo db create` and `buffalo db drop`.
