### PR TITLE
BelongsTo uses field name instead of type for ID field

### DIFF
--- a/associations/belongs_to_association.go
+++ b/associations/belongs_to_association.go
@@ -3,8 +3,6 @@ package associations
 import (
 	"fmt"
 	"reflect"
-
-	"github.com/markbates/inflect"
 )
 
 // belongsToAssociation is the implementation for the belongs_to
@@ -23,7 +21,7 @@ func init() {
 
 func belongsToAssociationBuilder(p associationParams) (Association, error) {
 	fval := p.modelValue.FieldByName(p.field.Name)
-	ownerIDField := fmt.Sprintf("%s%s", inflect.Capitalize(fval.Type().Name()), "ID")
+	ownerIDField := fmt.Sprintf("%s%s", p.field.Name, "ID")
 
 	if _, found := p.modelType.FieldByName(ownerIDField); !found {
 		return nil, fmt.Errorf("there is no '%s' defined in model '%s'", ownerIDField, p.modelType.Name())

--- a/associations/belongs_to_association_test.go
+++ b/associations/belongs_to_association_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 type fooBelongsTo struct {
-	ID         uuid.UUID   `db:"id"`
-	NestedBars []nestedBar `has_many:"nested_bars"`
+	ID uuid.UUID `db:"id"`
 }
 
 func (f fooBelongsTo) TableName() string {
@@ -25,18 +24,13 @@ type barBelongsTo struct {
 	Foo   fooBelongsTo `belongs_to:"foo"`
 }
 
-type nestedBar struct {
-	ID    uuid.UUID `db:"id"`
-	FooID uuid.UUID `db:"foo_id"`
-}
-
 func Test_Belongs_To_Association(t *testing.T) {
 	a := require.New(t)
 
 	id, _ := uuid.NewV1()
 	bar := barBelongsTo{FooID: id}
 
-	as, err := associations.AssociationsForStruct(&bar, "Foo.NestedBars")
+	as, err := associations.AssociationsForStruct(&bar, "Foo")
 	a.NoError(err)
 	a.Equal(len(as), 1)
 	a.Equal(reflect.Struct, as[0].Kind())

--- a/associations/belongs_to_association_test.go
+++ b/associations/belongs_to_association_test.go
@@ -21,21 +21,20 @@ func (f fooBelongsTo) TableName() string {
 }
 
 type barBelongsTo struct {
-	FooBelongsToID uuid.UUID    `db:"foo_id"`
-	Foo            fooBelongsTo `belongs_to:"foo"`
-	NestedBar      nestedBar    `has_one:"nestedBar"`
+	FooID uuid.UUID    `db:"foo_id"`
+	Foo   fooBelongsTo `belongs_to:"foo"`
 }
 
 type nestedBar struct {
-	ID             uuid.UUID `db:"id"`
-	fooBelongsToID uuid.UUID `db:"foo_belongs_to_id"`
+	ID    uuid.UUID `db:"id"`
+	FooID uuid.UUID `db:"foo_id"`
 }
 
 func Test_Belongs_To_Association(t *testing.T) {
 	a := require.New(t)
 
 	id, _ := uuid.NewV1()
-	bar := barBelongsTo{FooBelongsToID: id}
+	bar := barBelongsTo{FooID: id}
 
 	as, err := associations.AssociationsForStruct(&bar, "Foo.NestedBars")
 	a.NoError(err)

--- a/finders_test.go
+++ b/finders_test.go
@@ -148,7 +148,7 @@ func Test_Find_Eager_Has_One_With_Inner_Associations_Struct(t *testing.T) {
 		err = tx.Create(&composer)
 		a.NoError(err)
 
-		coolSong := Song{Title: "Hook", UserID: user.ID, ComposerID: composer.ID}
+		coolSong := Song{Title: "Hook", UserID: user.ID, ComposedByID: composer.ID}
 		err = tx.Create(&coolSong)
 		a.NoError(err)
 

--- a/migrations/20160808213310_setup_tests2.up.fizz
+++ b/migrations/20160808213310_setup_tests2.up.fizz
@@ -2,7 +2,7 @@ create_table("songs", func(t) {
   t.Column("id", "uuid", {"primary":true})
   t.Column("u_id", "int", {"null":true})
   t.Column("title", "string", {})
-  t.Column("composer_id", "int", {"null":true})
+  t.Column("composed_by_id", "int", {"null":true})
 })
 
 create_table("composers", func(t) {

--- a/pop_test.go
+++ b/pop_test.go
@@ -153,7 +153,7 @@ type Song struct {
 	UserID       int       `db:"u_id"`
 	CreatedAt    time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
-	ComposedByID int       `json:"composer_id" db:"composer_id"`
+	ComposedByID int       `json:"composed_by_id" db:"composed_by_id"`
 	ComposedBy   Composer  `belongs_to:"composer"`
 }
 

--- a/pop_test.go
+++ b/pop_test.go
@@ -148,13 +148,13 @@ type Enemy struct {
 }
 
 type Song struct {
-	ID         uuid.UUID `db:"id"`
-	Title      string    `db:"title"`
-	UserID     int       `db:"u_id"`
-	CreatedAt  time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at" db:"updated_at"`
-	ComposerID int       `json:"composer_id" db:"composer_id"`
-	ComposedBy Composer  `belongs_to:"composer"`
+	ID           uuid.UUID `db:"id"`
+	Title        string    `db:"title"`
+	UserID       int       `db:"u_id"`
+	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
+	ComposedByID int       `json:"composer_id" db:"composer_id"`
+	ComposedBy   Composer  `belongs_to:"composer"`
 }
 
 type Composer struct {


### PR DESCRIPTION
@markbates @larrymjordan @macrael This is a follow-up PR to [this issue](https://github.com/markbates/pop/issues/199) from the markbates repo.

This PR changes the behavior of `belongsTo` such that the ID field for `Foo fooType` is mapped to `FooID` instead of `FooTypeID`. This allows you to use `belongsTo` with multiple fields of the same type without the ID fields colliding with each other. This also jibes well with the [Rails](http://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-foreign-key) implementation of this relationship.