### PR TITLE
Expand Scope example to show chaining

### DIFF
--- a/scopes.go
+++ b/scopes.go
@@ -11,7 +11,7 @@ type ScopeFunc func(q *Query) *Query
 //		}
 //	}
 //
-//	q.Scope(ByName("mark").Where("id = ?", 1).First(&User{})
+//	q.Scope(ByName("mark").Where("id = ?", 1)).First(&User{})
 func (q *Query) Scope(sf ScopeFunc) *Query {
 	return sf(q)
 }
@@ -24,7 +24,13 @@ func (q *Query) Scope(sf ScopeFunc) *Query {
 //		}
 //	}
 //
-//	c.Scope(ByName("mark")).First(&User{})
+//	func NotDeleted() ScopeFunc {
+//		return func(q *Query) *Query {
+//			return q.Where("deleted_at IS NULL")
+//		}
+//	}
+//
+//	c.Scope(ByName("mark)).Scope(NotDeleted()).First(&User{})
 func (c *Connection) Scope(sf ScopeFunc) *Query {
 	return Q(c).Scope(sf)
 }


### PR DESCRIPTION
*Note: I'm happy to put this example somewhere else if it's too cumbersome to have in the source instead of a README or guide or wherever.*

## What
* Add more to the in-line example for `connection.Scope` to show using two `ScopeFunc`s at once
* Fix a typo (missing parens) in the `query.Scope` example

## Why
Just to make it a bit more obvious for the next docs reader 😄 