### PR TITLE
fizz/translators: support bigint primary keys in postgres

### DIFF
--- a/fizz/translators/postgres.go
+++ b/fizz/translators/postgres.go
@@ -27,6 +27,8 @@ func (p *Postgres) CreateTable(t fizz.Table) (string, error) {
 				s = fmt.Sprintf("\"%s\" %s PRIMARY KEY", c.Name, p.colType(c))
 			case "integer", "INT", "int":
 				s = fmt.Sprintf("\"%s\" SERIAL PRIMARY KEY", c.Name)
+			case "bigint", "BIGINT":
+				s = fmt.Sprintf("\"%s\" BIGSERIAL PRIMARY KEY", c.Name)
 			default:
 				return "", errors.Errorf("can not use %s as a primary key", c.ColType)
 			}


### PR DESCRIPTION
Previously fizz would not allow you to use `bigint` as a primary key type; this commit adds support using `bigserial` as the backing type.

Replaces PR #17.