### PR TITLE
fizz: define timestamp column types with a timezone

### DIFF
--- a/fizz/columns.go
+++ b/fizz/columns.go
@@ -14,8 +14,10 @@ var UUID_ID_COL = Column{
 	Options: Options{},
 }
 
-var CREATED_COL = Column{Name: "created_at", ColType: "timestamp", Options: Options{}}
-var UPDATED_COL = Column{Name: "updated_at", ColType: "timestamp", Options: Options{}}
+const defaultTimestampType = "timestamp with time zone"
+
+var CREATED_COL = Column{Name: "created_at", ColType: defaultTimestampType, Options: Options{}}
+var UPDATED_COL = Column{Name: "updated_at", ColType: defaultTimestampType, Options: Options{}}
 
 type Column struct {
 	Name    string

--- a/fizz/tables.go
+++ b/fizz/tables.go
@@ -50,7 +50,7 @@ func (t *Table) ForeignKey(column string, refs interface{}, options Options) {
 func (t *Table) Timestamp(name string) {
 	c := Column{
 		Name:    name,
-		ColType: "timestamp",
+		ColType: defaultTimestampType,
 		Options: Options{},
 	}
 


### PR DESCRIPTION
This CL makes the default timestamp (for 'created_at' and 'updated_at')
a "timestamp with time zone".

Updates gobuffalo/pop#23.