### PR TITLE
add flag to choose the type of migration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ If `development`is associated with a `postgresql`configuration, running this com
 ```text
 models/user.go
 models/user_test.go
-migrations/20170115024143_create_users.postgresql.up.sql
-migrations/20170115024143_create_users.postgresql.down.sql
+migrations/20170115024143_create_users.postgres.up.sql
+migrations/20170115024143_create_users.postgres.down.sql
 ```
 
 ### Migrations

--- a/README.md
+++ b/README.md
@@ -182,7 +182,20 @@ The `models/user.go` file contains a structure named `User` with fields `ID`, `C
 
 The `models/user_test.go` contains tests for the User model and they must be implemented by you.
 
-The other two files correspond to the migrations as explained below.
+The other two files correspond to the migrations as explained below. By default, it generates `.fizz` files but you can also generate `.sql` files by adding the flag `--migration-type sql` to the command. Be aware, that you will need to specify the appropriate environment, because `.sql` files are for specific databases.
+
+```bash
+$ soda generate model user name:text email:text --migration-type sql -e development
+```
+
+If `development`is associated with a `postgresql`configuration, running this command will generate the following files:
+
+```text
+models/user.go
+models/user_test.go
+migrations/20170115024143_create_users.postgresql.up.sql
+migrations/20170115024143_create_users.postgresql.down.sql
+```
 
 ### Migrations
 

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -167,7 +167,7 @@ func (m model) generateSQL(pathFlag, envFlag *pflag.Flag) error {
 		return err
 	}
 
-	err = pop.MigrationCreate(migrationPath, fmt.Sprintf("create_%s", m.Name.Table()), "sql", []byte(m.GenerateSQLFromFizz(m.Fizz(), db)), []byte(m.GenerateSQLFromFizz(m.UnFizz(), db)))
+	err = pop.MigrationCreate(migrationPath, fmt.Sprintf("create_%s.%s", m.Name.Table(), db.Dialect.Name()), "sql", []byte(m.GenerateSQLFromFizz(m.Fizz(), db)), []byte(m.GenerateSQLFromFizz(m.UnFizz(), db)))
 	if err != nil {
 		return err
 	}

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/pop/fizz"
 	"github.com/markbates/going/defaults"
 	"github.com/markbates/inflect"
 )
@@ -149,7 +150,7 @@ func (m model) generateModelFile() error {
 
 func (m model) generateFizz(cflag *pflag.Flag) error {
 	migrationPath := defaults.String(cflag.Value.String(), "./migrations")
-	err := pop.MigrationCreate(migrationPath, fmt.Sprintf("create_%s", m.Name.Table()), "fizz", []byte(m.Fizz()), []byte(fmt.Sprintf("drop_table(\"%s\")", m.Name.Table())))
+	err := pop.MigrationCreate(migrationPath, fmt.Sprintf("create_%s", m.Name.Table()), "fizz", []byte(m.Fizz()), []byte(m.UnFizz()))
 	if err != nil {
 		return err
 	}
@@ -157,6 +158,24 @@ func (m model) generateFizz(cflag *pflag.Flag) error {
 	return nil
 }
 
+func (m model) generateSQL(pathFlag, envFlag *pflag.Flag) error {
+	migrationPath := defaults.String(pathFlag.Value.String(), "./migrations")
+
+	env := envFlag.Value.String()
+	db, err := pop.Connect(env)
+	if err != nil {
+		return err
+	}
+
+	err = pop.MigrationCreate(migrationPath, fmt.Sprintf("create_%s", m.Name.Table()), "sql", []byte(m.GenerateSQLFromFizz(m.Fizz(), db)), []byte(m.GenerateSQLFromFizz(m.UnFizz(), db)))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Fizz generates the create table instructions
 func (m model) Fizz() string {
 	s := []string{fmt.Sprintf("create_table(\"%s\", func(t) {", m.Name.Table())}
 	for _, a := range m.Attributes {
@@ -174,6 +193,20 @@ func (m model) Fizz() string {
 	}
 	s = append(s, "})")
 	return strings.Join(s, "\n")
+}
+
+// UnFizz generates the drop table instructions
+func (m model) UnFizz() string {
+	return fmt.Sprintf("drop_table(\"%s\")", m.Name.Table())
+}
+
+// GenerateSQLFromFizz generates SQL instructions from fizz instructions
+func (m model) GenerateSQLFromFizz(content string, c *pop.Connection) string {
+	content, err := fizz.AString(content, c.Dialect.FizzTranslator())
+	if err != nil {
+		return ""
+	}
+	return content
 }
 
 func newModel(name string) model {

--- a/soda/cmd/generate/model_cmd.go
+++ b/soda/cmd/generate/model_cmd.go
@@ -11,11 +11,13 @@ import (
 
 var skipMigration bool
 var structTag string
+var migrationType string
 
 var nrx = regexp.MustCompile(`^nulls\.(.+)`)
 
 func init() {
 	ModelCmd.Flags().StringVarP(&structTag, "struct-tag", "", "json", "sets the struct tags for model (xml or json)")
+	ModelCmd.Flags().StringVarP(&migrationType, "migration-type", "", "fizz", "sets the type of migration files for model (sql or fizz)")
 	ModelCmd.Flags().BoolVarP(&skipMigration, "skip-migration", "s", false, "Skip creating a new fizz migration for this model.")
 
 	inflect.AddAcronym("ID")
@@ -60,7 +62,12 @@ var ModelCmd = &cobra.Command{
 			return nil
 		}
 
-		err = model.generateFizz(cmd.Flag("path"))
+		switch migrationType {
+		case "sql":
+			err = model.generateSQL(cmd.Flag("path"), cmd.Flag("env"))
+		default:
+			err = model.generateFizz(cmd.Flag("path"))
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Enables to choose the type of migration file you want during the model generation with flag ```--migration-type string``` 