### PR TITLE
Fixing ignored errors from fizz `exec()`

### DIFF
--- a/fizz/bubbler_test.go
+++ b/fizz/bubbler_test.go
@@ -13,7 +13,6 @@ func Test_Exec(t *testing.T) {
 	b := NewBubbler(nil)
 	f := fizzer{b}
 	bb := &bytes.Buffer{}
-	err := f.Exec(bb).(func(string) error)("echo hello")
-	r.NoError(err)
+	f.Exec(bb).(func(string))("echo hello")
 	r.Equal("hello\n", bb.String())
 }

--- a/fizz/fizz.go
+++ b/fizz/fizz.go
@@ -25,7 +25,7 @@ func (f fizzer) add(s string, err error) error {
 }
 
 func (f fizzer) Exec(out io.Writer) interface{} {
-	return func(s string) error {
+	return func(s string) {
 		args := strings.Split(s, " ")
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdin = os.Stdin
@@ -35,7 +35,6 @@ func (f fizzer) Exec(out io.Writer) interface{} {
 		if err != nil {
 			panic(fmt.Sprintf("error executing command: %s", s))
 		}
-		return nil
 	}
 }
 

--- a/fizz/fizz.go
+++ b/fizz/fizz.go
@@ -1,6 +1,7 @@
 package fizz
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -30,7 +31,11 @@ func (f fizzer) Exec(out io.Writer) interface{} {
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = out
 		cmd.Stderr = os.Stderr
-		return cmd.Run()
+		err := cmd.Run()
+		if err != nil {
+			panic(fmt.Sprintf("error executing command: %s", s))
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/gobuffalo/pop/issues/54

Anko doesn't seem to care if a function returns an error value, so the error returned by `Exec()` was being ignored. The most reasonable way to address this was to add a `panic`, similar to how [`add`](https://github.com/gobuffalo/pop/blob/master/fizz/fizz.go#L20) does.