### PR TITLE
[Postgres] LoadSchema using Go instead of psql tool

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -103,7 +103,7 @@ func (c *Connection) Open() error {
 	if err == nil {
 		c.Store = &dB{db}
 	}
-	return errors.Wrap(err, "coudn't connection to database")
+	return errors.Wrap(err, "couldn't connect to database")
 }
 
 // Close destroys an active datasource connection

--- a/postgresql.go
+++ b/postgresql.go
@@ -1,9 +1,9 @@
 package pop
 
 import (
-	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -180,32 +180,32 @@ func (p *postgresql) DumpSchema(w io.Writer) error {
 }
 
 func (p *postgresql) LoadSchema(r io.Reader) error {
-	cmd := exec.Command("psql", p.URL())
-	in, err := cmd.StdinPipe()
+	// Open DB connection on the target DB
+	deets := p.ConnectionDetails
+	db, err := sqlx.Open(deets.Dialect, p.MigrationURL())
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("unable to load schema for %s", deets.Database))
+	}
+	defer db.Close()
+
+	// Get reader contents
+	contents, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err
 	}
-	go func() {
-		defer in.Close()
-		io.Copy(in, r)
-	}()
-	Log(strings.Join(cmd.Args, " "))
 
-	bb := &bytes.Buffer{}
-	cmd.Stdout = bb
-	cmd.Stderr = bb
-
-	err = cmd.Start()
-	if err != nil {
-		return errors.WithMessage(err, bb.String())
+	if len(contents) == 0 {
+		fmt.Printf("schema is empty for %s, skipping\n", deets.Database)
+		return nil
 	}
 
-	err = cmd.Wait()
+	// From the sqlx package docs, this works with pq driver
+	_, err = db.Exec(string(contents))
 	if err != nil {
-		return errors.WithMessage(err, bb.String())
+		return errors.WithMessage(err, fmt.Sprintf("unable to load schema for %s", deets.Database))
 	}
 
-	fmt.Printf("loaded schema for %s\n", p.Details().Database)
+	fmt.Printf("loaded schema for %s\n", deets.Database)
 	return nil
 }
 

--- a/soda/cmd/schema/load.go
+++ b/soda/cmd/schema/load.go
@@ -25,6 +25,7 @@ var LoadCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer c.Close()
 
 		err = c.Dialect.LoadSchema(f)
 		if err != nil {


### PR DESCRIPTION
This PR replaces the call to `psql` to load a schema from a file with the equivalent in Go, for the postgresql driver.
This is an adaptation from [sqlx `LoadFile`](https://github.com/jmoiron/sqlx/blob/2aeb6a910c2b94f2d5eb53d9895d80e27264ec41/sqlx.go#L702).