### PR TITLE
Add tag flag to command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ go install github.com/gobuffalo/pop/soda
 
 ```bash
 $ go get -u -v -tags sqlite github.com/gobuffalo/pop/...
-$ go install github.com/gobuffalo/pop/soda
+$ go install -tags sqlite github.com/gobuffalo/pop/soda
 ```
 
 If you're not building your code with `buffalo build`, you'll also have to pass `-tags sqlite` to `go build` when building your program.


### PR DESCRIPTION
the tag is needed to install with sqlite support, with out it you get cryptic failures like...

```
[POP] 2018/05/13 15:13:37 Loading config file from %!s(MISSING)
 | ["/Users/jtang/sandbox/pop/database.yml"]
```