### PR TITLE
Fixes pointer referencing and nil checking for associations

### DIFF
--- a/finders.go
+++ b/finders.go
@@ -241,10 +241,16 @@ func (q *Query) eagerAssociations(model interface{}) error {
 		innerAssociations := association.InnerAssociations()
 		for _, inner := range innerAssociations {
 			v = reflect.Indirect(reflect.ValueOf(model)).FieldByName(inner.Name)
-			q.eagerFields = []string{inner.Fields}
-			err = q.eagerAssociations(v.Addr().Interface())
-			if err != nil {
-				return err
+			// only get address if not already a pointer
+			if v.Kind() != reflect.Ptr {
+				v = v.Addr()
+			}
+			if !v.IsNil() {
+				q.eagerFields = []string{inner.Fields}
+				err = q.eagerAssociations(v.Interface())
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We're using pointers to represent nullable fields on our project, and we were running into issues trying to load nested associations for pointer fields. One issue is that pointers were getting referenced into double pointers, and the second is that they weren't being nil-checked.