### PR TITLE
Replace SQL COUNT call for Exists with SQL EXISTS

### DIFF
--- a/finders.go
+++ b/finders.go
@@ -277,9 +277,9 @@ func (q *Query) Exists(model interface{}) (bool, error) {
 			query = query[0 : len(query)-len(foundLimit)]
 		}
 
-		countQuery := fmt.Sprintf("SELECT EXISTS (%s)", query)
-		Log(countQuery, args...)
-		return q.Connection.Store.Get(res, countQuery, args...)
+		existsQuery := fmt.Sprintf("SELECT EXISTS (%s)", query)
+		Log(existsQuery, args...)
+		return q.Connection.Store.Get(&res, existsQuery, args...)
 	})
 	return res, err
 }

--- a/finders.go
+++ b/finders.go
@@ -257,7 +257,7 @@ func (q *Query) eagerAssociations(model interface{}) error {
 // 	q.Where("name = ?", "mark").Exists(&User{})
 func (q *Query) Exists(model interface{}) (bool, error) {
 	tmpQuery := Q(q.Connection)
-	q.Clone(tmpQuery) //avoid mendling with original query
+	q.Clone(tmpQuery) //avoid meddling with original query
 
 	var res bool
 
@@ -303,7 +303,7 @@ func (q Query) Count(model interface{}) (int, error) {
 //	q.Where("sex = ?", "f").Count(&User{}, "name")
 func (q Query) CountByField(model interface{}, field string) (int, error) {
 	tmpQuery := Q(q.Connection)
-	q.Clone(tmpQuery) //avoid mendling with original query
+	q.Clone(tmpQuery) //avoid meddling with original query
 
 	res := &rowCount{}
 


### PR DESCRIPTION
This change makes use of the SQL `EXISTS` statement, so the DB doesn't need to count all the rows to check existence.