### PR TITLE
pop: update Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,12 +14,6 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/daviddengcn/go-colortext"
-  packages = ["."]
-  revision = "17e75f6184bc9e727756cd0d82e0af58b1fc7191"
-  version = "1.0.0"
-
-[[projects]]
   name = "github.com/fatih/color"
   packages = ["."]
   revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
@@ -117,39 +111,15 @@
   revision = "3e32b42850a9f09fac18a6c09bbd04325f51f732"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mattn/anko"
   packages = [
     "ast",
-    "builtins",
-    "builtins/encoding/json",
-    "builtins/errors",
-    "builtins/flag",
-    "builtins/fmt",
-    "builtins/github.com/daviddengcn/go-colortext",
-    "builtins/io",
-    "builtins/io/ioutil",
-    "builtins/math",
-    "builtins/math/big",
-    "builtins/math/rand",
-    "builtins/net",
-    "builtins/net/http",
-    "builtins/net/url",
-    "builtins/os",
-    "builtins/os/exec",
-    "builtins/os/signal",
-    "builtins/path",
-    "builtins/path/filepath",
-    "builtins/regexp",
-    "builtins/runtime",
-    "builtins/sort",
-    "builtins/strconv",
-    "builtins/strings",
-    "builtins/time",
+    "core",
     "parser",
     "vm"
   ]
-  revision = "d5441ca3f0c7e071a9ede864f9db2cc652690f42"
+  revision = "e9c5c0ca86cf129292c56ddbddc4fff027844d65"
+  version = "v0.0.4"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -242,6 +212,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "15861f98292e8eda4c9d11b9f59981ab94560772d787b97eeaa1728b32cc9e90"
+  inputs-digest = "be5f89623ebc72c1e48d90328642f9bf45ef80766479a040f579511bb4c7d857"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
The Gopkg.lock is broken if you use it with dep without an automatic update:

```
$ git clone https://github.com/gobuffalo/pop
Cloning into 'pop'...
remote: Counting objects: 5500, done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 5500 (delta 6), reused 12 (delta 5), pack-reused 5481
Receiving objects: 100% (5500/5500), 4.47 MiB | 13.12 MiB/s, done.
Resolving deltas: 100% (3129/3129), done.
$ cd pop
$ dep ensure -vendor-only
$ go build
fizz/bubbler.go:31:30: cannot use "github.com/gobuffalo/pop/vendor/github.com/mattn/anko/vm".NewEnv() (type *"github.com/gobuffalo/pop/vendor/github.com/mattn/anko/vm".Env) as type *"github.com/mattn/anko/vm".Env in argument to core.Import
$
```

This CL fixes the Gopkg.lock:

```
$ dep ensure
$ go build
$
```

Fixes #109.
Fixes #110.
Probably also gobuffalo/buffalo#1075.