### PR TITLE
Require that file names end in .sql or .fizz

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,12 +14,6 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/daviddengcn/go-colortext"
-  packages = ["."]
-  revision = "17e75f6184bc9e727756cd0d82e0af58b1fc7191"
-  version = "1.0.0"
-
-[[projects]]
   name = "github.com/fatih/color"
   packages = ["."]
   revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
@@ -117,39 +111,15 @@
   revision = "3e32b42850a9f09fac18a6c09bbd04325f51f732"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mattn/anko"
   packages = [
     "ast",
-    "builtins",
-    "builtins/encoding/json",
-    "builtins/errors",
-    "builtins/flag",
-    "builtins/fmt",
-    "builtins/github.com/daviddengcn/go-colortext",
-    "builtins/io",
-    "builtins/io/ioutil",
-    "builtins/math",
-    "builtins/math/big",
-    "builtins/math/rand",
-    "builtins/net",
-    "builtins/net/http",
-    "builtins/net/url",
-    "builtins/os",
-    "builtins/os/exec",
-    "builtins/os/signal",
-    "builtins/path",
-    "builtins/path/filepath",
-    "builtins/regexp",
-    "builtins/runtime",
-    "builtins/sort",
-    "builtins/strconv",
-    "builtins/strings",
-    "builtins/time",
+    "core",
     "parser",
     "vm"
   ]
-  revision = "d5441ca3f0c7e071a9ede864f9db2cc652690f42"
+  revision = "e9c5c0ca86cf129292c56ddbddc4fff027844d65"
+  version = "v0.0.4"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -242,6 +212,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "15861f98292e8eda4c9d11b9f59981ab94560772d787b97eeaa1728b32cc9e90"
+  inputs-digest = "be5f89623ebc72c1e48d90328642f9bf45ef80766479a040f579511bb4c7d857"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/migrator.go
+++ b/migrator.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var mrx = regexp.MustCompile(`(\d+)_([^\.]+)(\.[a-z0-9]+)?\.(up|down)\.(sql|fizz)`)
+var mrx = regexp.MustCompile(`(\d+)_([^\.]+)(\.[a-z0-9]+)?\.(up|down)\.(sql|fizz)$`)
 
 // NewMigrator returns a new "blank" migrator. It is recommended
 // to use something like MigrationBox or FileMigrator. A "blank"


### PR DESCRIPTION
Currently, Soda will consider any file that contains some sequence-stamped alphanumeric string, followed by `.up` or `.down`, followed by `.sql` or `.fizz`, as eligible for migration. While this narrows the search considerably, it doesn't account for files that contain `.sql` and `.fizz`—and otherwise match the pattern defined in mrx—but end in some _other_ file suffix.

For example, if you were to edit one of these migration files with Vim, you may have a file in the form of `.12345-whatever.up.sql.swp`. Soda will attempt to migrate this, but fail, for several reasons (besides the duplication of SQL logic, `swp` files contain Vim artifacts which Soda will not expect).

I propose here that files to be migrated _must end_ in either `.sql` or `.fizz`, not merely contain them.

One may additionally argue that Soda should not attempt to migrate hidden Unix files (those beginning with `.`); however, I do not address that in this PR.