### PR TITLE
Add a new version flag for the migrate up command

### DIFF
--- a/soda/cmd/migrate_up.go
+++ b/soda/cmd/migrate_up.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var migrationVersion string
+
 var migrateUpCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Apply all of the 'up' migrations.",
@@ -14,10 +16,14 @@ var migrateUpCmd = &cobra.Command{
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		if migrationVersion != "" {
+			return mig.Up(migrationVersion)
+		}
 		return mig.Up()
 	},
 }
 
 func init() {
 	migrateCmd.AddCommand(migrateUpCmd)
+	migrateUpCmd.Flags().StringVarP(&migrationVersion, "version", "v", "", "Apply a specific migration")
 }


### PR DESCRIPTION
This allows to apply a specific migration, just like in Rails (instead of applying the whole migration set). See http://guides.rubyonrails.org/active_record_migrations.html#running-specific-migrations

It this PR, only the up part is handled, not the down part.