### PR TITLE
Fix #66: Double schema.sql and different env behavior

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,20 +16,20 @@
 [[projects]]
   name = "github.com/fatih/color"
   packages = ["."]
-  revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
-  version = "v1.6.0"
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
 
 [[projects]]
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
-  revision = "a0583e0143b1624142adab07e0e97fe106d99561"
-  version = "v1.3"
+  revision = "d523deb1b23d913de5bdada721a6071e71283618"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/gobuffalo/envy"
   packages = ["."]
-  revision = "15f5083a6e269f8698715b13dd25f0538754ab37"
-  version = "v1.4.1"
+  revision = "2d0f467653f3d961ce9ada4d32a230bdcb3bfe11"
+  version = "v1.6.3"
 
 [[projects]]
   name = "github.com/gobuffalo/makr"
@@ -40,8 +40,8 @@
 [[projects]]
   name = "github.com/gobuffalo/packr"
   packages = ["."]
-  revision = "6434a292ac52e6964adebfdce3f9ce6d9f16be01"
-  version = "v1.10.4"
+  revision = "bd47f2894846e32edcf9aa37290fef76c327883f"
+  version = "v1.11.1"
 
 [[projects]]
   name = "github.com/gobuffalo/uuid"
@@ -71,7 +71,7 @@
     ".",
     "reflectx"
   ]
-  revision = "cf35089a197953c69420c8d0cecda90809764b1d"
+  revision = "0dae4fefe7c0e190f7b5a78dac28a1c82cc8d849"
 
 [[projects]]
   name = "github.com/joho/godotenv"
@@ -86,10 +86,9 @@
     ".",
     "oid"
   ]
-  revision = "88edab0803230a3898347e77b474f8c1820a1f20"
+  revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
 
 [[projects]]
-  branch = "master"
   name = "github.com/markbates/going"
   packages = [
     "defaults",
@@ -97,29 +96,31 @@
     "wait"
   ]
   revision = "0576708c56cea02331f864fe6e157ac7841923e4"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/markbates/grift"
   packages = ["grift"]
-  revision = "5499956ce4d9ef7fddc825ea7cb26744eeac3d79"
+  revision = "76f93617a788d350124f749acb3790276a436cc0"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/markbates/inflect"
   packages = ["."]
-  revision = "3e32b42850a9f09fac18a6c09bbd04325f51f732"
+  revision = "dd7de90c06bca70f18136e59dec2270c19a401e7"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/mattn/anko"
   packages = [
     "ast",
     "core",
+    "internal/corelib",
     "parser",
     "vm"
   ]
-  revision = "e9c5c0ca86cf129292c56ddbddc4fff027844d65"
-  version = "v0.0.4"
+  revision = "9bd0532a673bf760bb6cb5577b3b1574c96537a0"
+  version = "v0.0.5"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -136,14 +137,8 @@
 [[projects]]
   name = "github.com/mattn/go-sqlite3"
   packages = ["."]
-  revision = "6c771bb9887719704b210e87e934f08be014bdb1"
-  version = "v1.6.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/go-homedir"
-  packages = ["."]
-  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+  revision = "25ecb14adfc7543176f7d85291ec7dba82c6f7e4"
+  version = "v1.9.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -166,14 +161,14 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
-  version = "v0.0.1"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -182,32 +177,38 @@
     "require",
     "suite"
   ]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "22ae77b79946ea320088417e4d50825671d82d57"
+  revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
+  revision = "fc8bd948cf46f9c7af0f07d34151ce25fe90e477"
+
+[[projects]]
+  name = "google.golang.org/appengine"
+  packages = ["cloudsql"]
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/net v0.0.0-20180611182652-db08ff08e862
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
-	golang.org/x/sys v0.0.0-20180616030259-6c888cc515d3
+	golang.org/x/sys v0.0.0-20180619160947-fc8bd948cf46
 	gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/soda/cmd/schema/dump.go
+++ b/soda/cmd/schema/dump.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,6 +20,11 @@ var DumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Dumps out the schema of the selected database",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		env := cmd.Flag("env")
+		if env == nil {
+			return errors.New("env is required")
+		}
+		dumpOptions.env = env.Value.String()
 		c, err := pop.Connect(dumpOptions.env)
 		if err != nil {
 			return err
@@ -41,6 +47,5 @@ var DumpCmd = &cobra.Command{
 }
 
 func init() {
-	DumpCmd.Flags().StringVarP(&dumpOptions.env, "env", "e", "development", "The environment you want to run schema against. Will use $GO_ENV if set.")
-	DumpCmd.Flags().StringVarP(&dumpOptions.output, "output", "o", "schema.sql", "The path to dump the schema to.")
+	DumpCmd.Flags().StringVarP(&dumpOptions.output, "output", "o", "./migrations/schema.sql", "The path to dump the schema to.")
 }

--- a/soda/cmd/schema/load.go
+++ b/soda/cmd/schema/load.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/gobuffalo/pop"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -17,14 +18,20 @@ var LoadCmd = &cobra.Command{
 	Use:   "load",
 	Short: "Load a schema.sql file into a database",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		env := cmd.Flag("env")
+		if env == nil {
+			return errors.New("env is required")
+		}
+		loadOptions.env = env.Value.String()
+
 		f, err := os.Open(loadOptions.input)
 		if err != nil {
-			return err
+			return errors.WithMessage(err, "unable to load schema file")
 		}
 
 		c, err := pop.Connect(loadOptions.env)
 		if err != nil {
-			return err
+			return errors.WithMessage(err, "unable to connect to database")
 		}
 		defer c.Close()
 
@@ -33,6 +40,5 @@ var LoadCmd = &cobra.Command{
 }
 
 func init() {
-	LoadCmd.Flags().StringVarP(&loadOptions.env, "env", "e", "development", "The environment you want to run schema against. Will use $GO_ENV if set.")
-	LoadCmd.Flags().StringVarP(&loadOptions.input, "input", "i", "schema.sql", "The path to the schema file you want to load")
+	LoadCmd.Flags().StringVarP(&loadOptions.input, "input", "i", "./migrations/schema.sql", "The path to the schema file you want to load")
 }


### PR DESCRIPTION
* Fix default values for schema subcommands, so it's dumped and read from
the same default location.
* schema subcommands now use the same value for env as the root one.