### PR TITLE
Fix #21: Handle encoding for MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ before_script:
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter --install
   - go build -v -tags sqlite -o tsoda ./soda
-  # travis hangs when trying to create mysql db using soda. not sure why
-  - mysql -e 'create database pop_test;'
+  - ./tsoda create -e "mysql_travis"
   - ./tsoda create -e "postgres"
   - ./tsoda create -e "sqlite"
   - ./tsoda migrate -e "mysql_travis"

--- a/connection_details.go
+++ b/connection_details.go
@@ -28,6 +28,8 @@ type ConnectionDetails struct {
 	User string
 	// The password of the database user. Example: "password"
 	Password string
+	// The encoding to use to create the database and communicate with it.
+	Encoding string
 	// Instead of specifying each individual piece of the
 	// connection you can instead just specify the URL of the
 	// database. Example: "postgres://postgres:postgres@localhost:5432/pop_test?sslmode=disable"

--- a/database.yml
+++ b/database.yml
@@ -5,6 +5,7 @@ mysql:
   port: {{ envOr "MYSQL_PORT" "3306"  }}
   user: {{ envOr "MYSQL_USER"  "root"  }}
   password: {{ envOr "MYSQL_PASSWORD"  "root"  }}
+  encoding: "utf8mb4_general_ci"
 
 mysql_travis:
   dialect: "mysql"
@@ -13,6 +14,7 @@ mysql_travis:
   port: {{ envOr "MYSQL_PORT" "3306"  }}
   user: {{ envOr "MYSQL_USER"  "root"  }}
   password: {{ envOr "MYSQL_PASSWORD"  ""  }}
+  encoding: "utf8mb4_general_ci"
 
 postgres:
   url: "postgres://postgres:postgres@localhost:5432/pop_test?sslmode=disable"

--- a/finders_test.go
+++ b/finders_test.go
@@ -26,6 +26,23 @@ func Test_Find(t *testing.T) {
 	})
 }
 
+func Test_Find_UTF8(t *testing.T) {
+	transaction(func(tx *pop.Connection) {
+		r := require.New(t)
+
+		user := User{Name: nulls.NewString("💩")}
+		err := tx.Create(&user)
+		r.NoError(err)
+
+		u := User{}
+		err = tx.Find(&u, user.ID)
+		r.NoError(err)
+
+		r.NotEqual(u.ID, 0)
+		r.Equal(u.Name.String, "💩")
+	})
+}
+
 func Test_Select(t *testing.T) {
 	transaction(func(tx *pop.Connection) {
 		r := require.New(t)

--- a/soda/cmd/generate/config_templates.go
+++ b/soda/cmd/generate/config_templates.go
@@ -21,6 +21,7 @@ var mysqlConfig = `development:
   port: "3306"
   user: "root"
   password: "root"
+  encoding: "utf8mb4_general_ci"
 
 test:
   url: {{"{{"}}envOr "TEST_DATABASE_URL" "mysql://root:root@(localhost:3306)/{{.name}}_test?parseTime=true&multiStatements=true&readTimeout=1s"}}


### PR DESCRIPTION
* Keep the default encoding to "utf8_general_ci" to not break current setups.
* Generate the templates with the "utf8mb4_general_ci" encoding, for new apps.
* New "encoding" param to set the encoding for DB creation & connection.