### PR TITLE
Small Fix for issue #156

### DIFF
--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -176,7 +176,7 @@ func (m model) Fizz() string {
 			s = append(s, x)
 		}
 	}
-	s = append(s, "})")
+	s = append(s, "}")
 	return strings.Join(s, "\n")
 }
 


### PR DESCRIPTION
Even if the issue is written as closed: https://github.com/gobuffalo/pop/issues/156, a closing parenthesis at the end of the fizz file was showing the warning about old style fizz.