### PR TITLE
Changes pgTruncate to Truncate all schemas

### DIFF
--- a/postgresql.go
+++ b/postgresql.go
@@ -204,7 +204,7 @@ BEGIN
    FOR _sch, _tbl IN
       SELECT schemaname, tablename 
       FROM   pg_tables 
-      WHERE  table_name <> schema_migration AND schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
+      WHERE  table_name <> 'schema_migration' AND schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
    LOOP
       --RAISE ERROR '%',
       EXECUTE  -- dangerous, test before you execute!

--- a/postgresql.go
+++ b/postgresql.go
@@ -207,7 +207,7 @@ BEGIN
    FOR _sch, _tbl IN
       SELECT schemaname, tablename 
       FROM   pg_tables 
-      WHERE  table_name <> '%s' AND schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
+      WHERE  tablename <> '%s' AND schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
    LOOP
       --RAISE ERROR '%%',
       EXECUTE  -- dangerous, test before you execute!

--- a/postgresql.go
+++ b/postgresql.go
@@ -202,9 +202,9 @@ DECLARE
    _sch text;
 BEGIN
    FOR _sch, _tbl IN
-      SELECT schemaname, tablename
+      SELECT schemaname, tablename, tableowner
       FROM   pg_tables
-      WHERE    schemaname <> 'pg_catalog'
+      WHERE  schemaname <> 'pg_catalog' AND tableowner = current_user
    LOOP
       --RAISE ERROR '%',
       EXECUTE  -- dangerous, test before you execute!

--- a/postgresql.go
+++ b/postgresql.go
@@ -183,7 +183,7 @@ func (p *postgresql) LoadSchema(r io.Reader) error {
 
 // TruncateAll truncates all tables for the given connection.
 func (p *postgresql) TruncateAll(tx *Connection) error {
-	return tx.RawQuery(pgTruncate).Exec()
+	return tx.RawQuery(pgTruncate, tx.MigrationTableName()).Exec()
 }
 
 func newPostgreSQL(deets *ConnectionDetails) dialect {
@@ -204,11 +204,11 @@ BEGIN
    FOR _sch, _tbl IN
       SELECT schemaname, tablename 
       FROM   pg_tables 
-      WHERE  table_name <> 'schema_migration' AND schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
+      WHERE  table_name <> '%s' AND schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
    LOOP
-      --RAISE ERROR '%',
+      --RAISE ERROR '%%',
       EXECUTE  -- dangerous, test before you execute!
-         format('TRUNCATE TABLE %I.%I CASCADE', _sch, _tbl);
+         format('TRUNCATE TABLE %%I.%%I CASCADE', _sch, _tbl);
    END LOOP;
 END
 $func$;`

--- a/postgresql.go
+++ b/postgresql.go
@@ -203,8 +203,8 @@ DECLARE
 BEGIN
    FOR _sch, _tbl IN
       SELECT schemaname, tablename 
-      FROM pg_tables 
-      WHERE  schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user;
+      FROM   pg_tables 
+      WHERE  schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
    LOOP
       --RAISE ERROR '%',
       EXECUTE  -- dangerous, test before you execute!

--- a/postgresql.go
+++ b/postgresql.go
@@ -204,7 +204,7 @@ BEGIN
    FOR _sch, _tbl IN
       SELECT schemaname, tablename 
       FROM   pg_tables 
-      WHERE  schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
+      WHERE  table_name <> schema_migration AND schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user
    LOOP
       --RAISE ERROR '%',
       EXECUTE  -- dangerous, test before you execute!

--- a/postgresql.go
+++ b/postgresql.go
@@ -183,7 +183,7 @@ func (p *postgresql) LoadSchema(r io.Reader) error {
 
 // TruncateAll truncates all tables for the given connection.
 func (p *postgresql) TruncateAll(tx *Connection) error {
-	return tx.RawQuery(pgTruncate, tx.MigrationTableName()).Exec()
+	return tx.RawQuery(fmt.Sprintf(pgTruncate, tx.MigrationTableName())).Exec()
 }
 
 func newPostgreSQL(deets *ConnectionDetails) dialect {

--- a/postgresql.go
+++ b/postgresql.go
@@ -202,9 +202,9 @@ DECLARE
    _sch text;
 BEGIN
    FOR _sch, _tbl IN
-      SELECT schemaname, tablename, tableowner
-      FROM   pg_tables
-      WHERE  schemaname <> 'pg_catalog' AND tableowner = current_user
+      SELECT schemaname, tablename 
+      FROM pg_tables 
+      WHERE  schemaname NOT IN ('pg_catalog', 'information_schema') AND tableowner = current_user;
    LOOP
       --RAISE ERROR '%',
       EXECUTE  -- dangerous, test before you execute!

--- a/postgresql.go
+++ b/postgresql.go
@@ -204,7 +204,7 @@ BEGIN
    FOR _sch, _tbl IN
       SELECT schemaname, tablename
       FROM   pg_tables
-      WHERE    schemaname = 'public'
+      WHERE    schemaname <> 'pg_catalog'
    LOOP
       --RAISE ERROR '%',
       EXECUTE  -- dangerous, test before you execute!


### PR DESCRIPTION
As discussed in Slack if you have multiple schemas TruncateAll is only truncating tables in `public` schema, this change truncates the rest of the schema tables as well.