### PR TITLE
Add escape for special column names

### DIFF
--- a/columns/column.go
+++ b/columns/column.go
@@ -12,7 +12,7 @@ type Column struct {
 
 // UpdateString returns the SQL statement to UPDATE the column.
 func (c Column) UpdateString() string {
-	return fmt.Sprintf("%s = :%s", c.Name, c.Name)
+	return fmt.Sprintf("`%s` = :%s", c.Name, c.Name)
 }
 
 // SetSelectSQL sets a custom SELECT statement for the column.

--- a/columns/column_test.go
+++ b/columns/column_test.go
@@ -10,5 +10,5 @@ import (
 func Test_Column_UpdateString(t *testing.T) {
 	r := require.New(t)
 	c := columns.Column{Name: "foo"}
-	r.Equal(c.UpdateString(), "foo = :foo")
+	r.Equal(c.UpdateString(), "`foo` = :foo")
 }

--- a/columns/columns.go
+++ b/columns/columns.go
@@ -125,7 +125,7 @@ func (c Columns) String() string {
 		xs = append(xs, t.Name)
 	}
 	sort.Strings(xs)
-	return strings.Join(xs, ", ")
+	return "`" + strings.Join(xs, "`, `") + "`"
 }
 
 // SymbolizedString returns a list of tokens (:token) to bind

--- a/columns/readable_columns_test.go
+++ b/columns/readable_columns_test.go
@@ -12,7 +12,7 @@ func Test_Columns_ReadableString(t *testing.T) {
 	for _, f := range []interface{}{foo{}, &foo{}} {
 		c := columns.ForStruct(f, "foo")
 		u := c.Readable().String()
-		r.Equal(u, "LastName, first_name, read")
+		r.Equal(u, "`LastName`, `first_name`, `read`")
 	}
 }
 

--- a/columns/writeable_columns_test.go
+++ b/columns/writeable_columns_test.go
@@ -30,6 +30,6 @@ func Test_Columns_WriteableString(t *testing.T) {
 	for _, f := range []interface{}{foo{}, &foo{}} {
 		c := columns.ForStruct(f, "foo")
 		u := c.Writeable().String()
-		r.Equal(u, "LastName, write")
+		r.Equal(u, "`LastName`, `write`")
 	}
 }

--- a/columns/writeable_columns_test.go
+++ b/columns/writeable_columns_test.go
@@ -21,7 +21,7 @@ func Test_Columns_UpdateString(t *testing.T) {
 	for _, f := range []interface{}{foo{}, &foo{}} {
 		c := columns.ForStruct(f, "foo")
 		u := c.Writeable().UpdateString()
-		r.Equal(u, "LastName = :LastName, write = :write")
+		r.Equal(u, "`LastName` = :LastName, `write` = :write")
 	}
 }
 


### PR DESCRIPTION
Some column names like "group" will cause syntax error when executed in MySQL. 