### PR TITLE
Fix test fizz migrations to include an ID

### DIFF
--- a/migrations/20160808213308_setup_tests.up.fizz
+++ b/migrations/20160808213308_setup_tests.up.fizz
@@ -1,4 +1,5 @@
 create_table("users") {
+  t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
   t.Column("user_name", "string", {"size": 100})
   t.Column("alive", "boolean", {"null": true})
@@ -8,16 +9,20 @@ create_table("users") {
   t.Column("email", "string", {"default": "foo@example.com", "size": 50})
 }
 create_table("good_friends") {
+  t.Column("id", "int", {primary: true})
   t.Column("first_name", "string", {})
   t.Column("last_name", "string", {})
 }
 create_table("validatable_cars") {
+  t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
 }
 create_table("not_validatable_cars") {
+  t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
 }
 create_table("callbacks_users") {
+  t.Column("id", "int", {primary: true})
   t.Column("before_s", "string", {})
   t.Column("before_c", "string", {})
   t.Column("before_u", "string", {})
@@ -29,15 +34,18 @@ create_table("callbacks_users") {
   t.Column("after_f", "string", {})
 }
 create_table("books") {
+  t.Column("id", "int", {primary: true})
   t.Column("title", "string", {})
   t.Column("user_id", "int", {"null": true})
   t.Column("isbn", "string", {"size": 50})
 }
 create_table("taxis") {
+  t.Column("id", "int", {primary: true})
   t.Column("model", "string", {})
   t.Column("user_id", "int", {"null": true})
 }
 create_table("user_attributes") {
+  t.Column("id", "int", {primary: true})
   t.Column("user_name", "string", {"size": 100})
   t.Column("nick_name", "string", {})
   t.DisableTimestamps()

--- a/migrations/20160808213310_setup_tests2.up.fizz
+++ b/migrations/20160808213310_setup_tests2.up.fizz
@@ -5,17 +5,21 @@ create_table("songs") {
   t.Column("composed_by_id", "int", {"null":true})
 }
 create_table("composers") {
+  t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
 }
 create_table("writers") {
+  t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
   t.Column("book_id", "int", {})
 }
 create_table("addresses") {
+  t.Column("id", "int", {primary: true})
   t.Column("street", "string", {})
   t.Column("house_number", "int", {})
 }
 create_table("users_addresses") {
+  t.Column("id", "int", {primary: true})
   t.Column("user_id", "int", {})
   t.Column("address_id", "int", {})
 }
@@ -32,6 +36,7 @@ create_table("labels") {
 }
 {{ if eq .Dialect "postgres" -}}
   create_table("cakes") {
+    t.Column("id", "int", {primary: true})
     t.Column("int_slice", "int[]", {"null": true})
     t.Column("float_slice", "numeric[]", {"null": true})
     t.Column("string_slice", "varchar[]", {"null": true})


### PR DESCRIPTION
Since fizz is not adding the ID column by itself anymore, we have to change the test migrations a bit.
THis change doesn't affect users, since soda/buffalo db already generated the ID for users.