### PR TITLE
Added primary_id functionality to the many to many relationship 

### DIFF
--- a/associations/many_to_many_association.go
+++ b/associations/many_to_many_association.go
@@ -17,6 +17,7 @@ type manyToManyAssociation struct {
 	owner               interface{}
 	fkID                string
 	orderBy             string
+	primaryID           string
 	*associationSkipable
 	*associationComposite
 }
@@ -38,6 +39,7 @@ func init() {
 			manyToManyTableName: p.popTags.Find("many_to_many").Value,
 			fkID:                p.popTags.Find("fk_id").Value,
 			orderBy:             p.popTags.Find("order_by").Value,
+			primaryID:           p.popTags.Find("primary_id").Value,
 			associationSkipable: &associationSkipable{
 				skipped: skipped,
 			},
@@ -83,6 +85,10 @@ func (m *manyToManyAssociation) Constraint() (string, []interface{}) {
 
 	if m.fkID != "" {
 		columnFieldID = m.fkID
+	}
+
+	if m.primaryID != "" {
+	   modelColumnID = m.primaryID
 	}
 
 	subQuery := fmt.Sprintf("select %s from %s where %s = ?", columnFieldID, m.manyToManyTableName, modelColumnID)

--- a/associations/many_to_many_association_test.go
+++ b/associations/many_to_many_association_test.go
@@ -10,8 +10,13 @@ import (
 )
 
 type fooManyToMany struct {
+	ID                  uuid.UUID       `db:"id"`
+	BarManyToManies     barManyToManies `many_to_many:"foos_and_bars"`
+}
+
+type fooManyToMany2 struct {
 	ID              uuid.UUID       `db:"id"`
-	BarManyToManies barManyToManies `many_to_many:"foos_and_bars"`
+	BarManyToManies barManyToManies `many_to_many:"foos_and_bars" primary_id:"fufu_id"`
 }
 
 type barManyToMany struct {
@@ -39,5 +44,23 @@ func Test_Many_To_Many_Association(t *testing.T) {
 
 	where, args := as[0].Constraint()
 	a.Equal("id in (select bar_many_to_many_id from foos_and_bars where foo_many_to_many_id = ?)", where)
+	a.Equal(id, args[0].(uuid.UUID))
+}
+
+func Test_Many_To_Many_PrimaryId_Tag(t *testing.T) {
+	a := require.New(t)
+
+	id, _ := uuid.NewV1()
+	foo := fooManyToMany2{ID: id}
+
+	as, err := associations.ForStruct(&foo)
+
+	a.NoError(err)
+	a.Equal(len(as), 1)
+
+	a.Equal(reflect.Slice, as[0].Kind())
+
+	where, args := as[0].Constraint()
+	a.Equal("id in (select bar_many_to_many_id from foos_and_bars where fufu_id = ?)", where)
 	a.Equal(id, args[0].(uuid.UUID))
 }


### PR DESCRIPTION
The referencing column name can be set using the primary_id tag in the struct.

The reason for this change is that I have two structs that read from the same DB column that have different concerns.