### PR TITLE
Add contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to POP
+
+First, thank you so much for wanting to contribute! It means so much that you care enough to want to contribute. We appreciate every PR from the smallest of typos to the be biggest of features.
+
+Please open PRs against the `development` branch. **_DO NOT_** open one against `master` unless you are explicitly told to. All "unreleased" work happens in the `development` branch.
+
+Also make sure to check [Buffalo's contributing guidelines](https://github.com/gobuffalo/buffalo/blob/development/.github/CONTRIBUTING.md) before starting to contribute.


### PR DESCRIPTION
It provides some basic information, but mostly links to the main repo's guidelines to reduce duplication and make maintaining the guidelines easier.

I opened my first PR against master instead of development because I did not consider looking for contribution guidelines in the main repo.  This should help future first-time contributors to get it right the first time and me to remember to check the base branch before opening a PR.