### PR TITLE
Drop command requires user confirmation or -y flag and does not allow arguments.

### DIFF
--- a/soda/cmd/drop.go
+++ b/soda/cmd/drop.go
@@ -5,15 +5,35 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/spf13/cobra"
-)
+	"os"
+	"bufio"
+	)
 
 var all bool
+var confirmed bool
 
 var dropCmd = &cobra.Command{
 	Use:   "drop",
 	Short: "Drops databases for you",
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
+		if len(args) > 1 {
+			err = fmt.Errorf("No arguments are allowed with the drop database command.")
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if !confirmed {
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Print("Do you really want to drop the database (y)? ")
+			text, _ := reader.ReadString('\n')
+			if text != "y" && text != "Y" {
+				fmt.Println("Aborting due to lack of user confirmation.")
+				os.Exit(0)
+			}
+
+		}
+
 		if all {
 			for _, conn := range pop.Connections {
 				err = pop.DropDB(conn)
@@ -31,5 +51,6 @@ var dropCmd = &cobra.Command{
 
 func init() {
 	dropCmd.Flags().BoolVarP(&all, "all", "a", false, "Drops all of the databases in the database.yml")
+	dropCmd.Flags().BoolVarP(&confirmed, "confirmed", "y", false, "Runs without asking the user for confirmation")
 	RootCmd.AddCommand(dropCmd)
 }

--- a/soda/cmd/drop.go
+++ b/soda/cmd/drop.go
@@ -17,8 +17,8 @@ var dropCmd = &cobra.Command{
 	Short: "Drops databases for you",
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if len(args) > 1 {
-			err = fmt.Errorf("No arguments are allowed with the drop database command.")
+		if len(args) > 0 {
+			err = fmt.Errorf("No arguments allowed with the drop database command.")
 			fmt.Println(err)
 			os.Exit(1)
 		}
@@ -51,6 +51,6 @@ var dropCmd = &cobra.Command{
 
 func init() {
 	dropCmd.Flags().BoolVarP(&all, "all", "a", false, "Drops all of the databases in the database.yml")
-	dropCmd.Flags().BoolVarP(&confirmed, "confirmed", "y", false, "Runs without asking the user for confirmation")
+	dropCmd.Flags().BoolVarP(&confirmed, "yes", "y", false, "Runs without asking the user for confirmation")
 	RootCmd.AddCommand(dropCmd)
 }


### PR DESCRIPTION
This is in relation to issue [#220](https://github.com/gobuffalo/pop/issues/220).