### PR TITLE
Improve bad configuration file errors reporting

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// ErrConfigFileNotFound is returned when the pop config file can't be found,
+// after looking for it.
+var ErrConfigFileNotFound = errors.New("unable to find pop config file")
+
 var lookupPaths = []string{"", "./config", "/config", "../", "../config", "../..", "../../config"}
 
 // ConfigName is the name of the YAML databases config file
@@ -31,7 +35,9 @@ func init() {
 	if ap != "" {
 		AddLookupPaths(ap)
 	}
-	LoadConfigFile()
+	if err := LoadConfigFile(); err != nil {
+		log(logging.Error, "Unable to load config file: %v", err)
+	}
 }
 
 // LoadConfigFile loads a POP config file from the configured lookup paths
@@ -41,7 +47,7 @@ func LoadConfigFile() error {
 		return errors.WithStack(err)
 	}
 	Connections = map[string]*Connection{}
-	log(logging.Info, "Loading config file from %s", path)
+	log(logging.Debug, "Loading config file from %s", path)
 	f, err := os.Open(path)
 	if err != nil {
 		return errors.WithStack(err)
@@ -67,7 +73,7 @@ func findConfigPath() (string, error) {
 			return path, err
 		}
 	}
-	return "", errors.New("tried to load pop configuration file, but couldn't find it")
+	return "", ErrConfigFileNotFound
 }
 
 // LoadFrom reads a configuration from the reader and sets up the connections
@@ -105,7 +111,8 @@ func LoadFrom(r io.Reader) error {
 	for n, d := range deets {
 		con, err := NewConnection(d)
 		if err != nil {
-			return err
+			log(logging.Warn, "unable to load connection %s: %v", n, err)
+			continue
 		}
 		Connections[n] = con
 	}

--- a/connection.go
+++ b/connection.go
@@ -10,11 +10,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Connections contains all of the available connections
+// Connections contains all available connections
 var Connections = map[string]*Connection{}
 
-// Connection represents all of the necessary details for
-// talking with a datastore
+// Connection represents all necessary details to talk with a datastore
 type Connection struct {
 	ID          string
 	Store       store
@@ -85,7 +84,7 @@ func Connect(e string) (*Connection, error) {
 	e = defaults.String(e, "development")
 	c := Connections[e]
 	if c == nil {
-		return c, errors.Errorf("Could not find connection named %s!", e)
+		return c, errors.Errorf("could not find connection named %s", e)
 	}
 	err := c.Open()
 	return c, errors.Wrapf(err, "couldn't open connection for %s", e)

--- a/connection_details.go
+++ b/connection_details.go
@@ -117,7 +117,7 @@ func (cd *ConnectionDetails) Finalize() error {
 	case "sqlite", "sqlite3":
 		cd.Dialect = "sqlite3"
 	default:
-		return errors.Errorf("Unknown dialect %s!", cd.Dialect)
+		return errors.Errorf("unknown dialect %s", cd.Dialect)
 	}
 	return nil
 }

--- a/logging/const.go
+++ b/logging/const.go
@@ -4,14 +4,16 @@ package logging
 type Level int
 
 const (
-	// SQL level is the lowest logger level. It dumps Debug level + SQL queries.
+	// SQL level is the lowest logger level. It dumps all logs.
 	SQL Level = iota
-	// Debug level dumps debug log traces and info logs.
+	// Info level dumps logs with higher or equal severity than debug.
 	Debug
-	// Info level dumps info logs and warnings.
+	// Info level dumps logs with higher or equal severity than info.
 	Info
-	// Warn level dumps warnings.
+	// Warn level dumps logs with higher or equal severity than warning.
 	Warn
+	// Error level dumps logs only errors.
+	Error
 )
 
 func (l Level) String() string {
@@ -24,6 +26,8 @@ func (l Level) String() string {
 		return "info"
 	case Warn:
 		return "warn"
+	case Error:
+		return "error"
 	}
 	return "unknown"
 }

--- a/logging/const.go
+++ b/logging/const.go
@@ -6,7 +6,7 @@ type Level int
 const (
 	// SQL level is the lowest logger level. It dumps all logs.
 	SQL Level = iota
-	// Info level dumps logs with higher or equal severity than debug.
+	// Debug level dumps logs with higher or equal severity than debug.
 	Debug
 	// Info level dumps logs with higher or equal severity than info.
 	Info

--- a/sqlite_shim.go
+++ b/sqlite_shim.go
@@ -7,5 +7,5 @@ import (
 )
 
 func newSQLite(deets *ConnectionDetails) (dialect, error) {
-	return nil, errors.New("sqlite3 was not compiled into the binary")
+	return nil, errors.New("sqlite3 support was not compiled into the binary")
 }


### PR DESCRIPTION
This PR will help to troubleshoot configuration file errors:
* Add an Error level for the logger.
* Log config file loading errors.
* Prevent a bad connection declaration to abort Connections parsing.