### PR TITLE
Refactor model cmd config

### DIFF
--- a/soda/cmd/generate/attribute.go
+++ b/soda/cmd/generate/attribute.go
@@ -16,10 +16,11 @@ type attribute struct {
 	GoType            string
 	Nullable          bool
 	PreventValidation bool
+	StructTag         string
 }
 
 func (a attribute) String() string {
-	return fmt.Sprintf("\t%s %s `%s:\"%s\" db:\"%s\"`", a.Name.Pascalize(), a.GoType, structTag, a.Name.Underscore(), a.Name.Underscore())
+	return fmt.Sprintf("\t%s %s `%s:\"%s\" db:\"%s\"`", a.Name.Pascalize(), a.GoType, a.StructTag, a.Name.Underscore(), a.Name.Underscore())
 }
 
 func (a attribute) IsValidable() bool {
@@ -57,6 +58,7 @@ func newAttribute(base string, model *model) (attribute, error) {
 		OriginalType: col[1],
 		GoType:       got,
 		Nullable:     nullable,
+		StructTag:    model.StructTag,
 	}
 
 	return a, nil

--- a/soda/cmd/generate/attribute_test.go
+++ b/soda/cmd/generate/attribute_test.go
@@ -41,7 +41,8 @@ func Test_Attribute_String(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		model := newModel("car")
+		model, err := newModel("car", "json")
+		r.NoError(err)
 		a, err := newAttribute(c.name, &model)
 		r.NoError(err)
 		r.Equal(c.exp, a.String())
@@ -125,7 +126,8 @@ func Test_newAttribute(t *testing.T) {
 	for index, tcase := range cases {
 		t.Run(fmt.Sprintf("%d-%s", index, tcase.AttributeInput), func(tt *testing.T) {
 			r := require.New(tt)
-			model := newModel("car")
+			model, err := newModel("car", "json")
+			r.NoError(err)
 			a, err := newAttribute(tcase.AttributeInput, &model)
 			if tcase.Invalid {
 				r.Errorf(err, "%s should be an invalid attribute", tcase.AttributeInput)

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -235,8 +235,8 @@ func newModel(name string, structTag string) (model, error) {
 		return model{}, errors.New("invalid struct tags (use xml or json)")
 	}
 
-	m.addAttribute(attribute{Name: flect.New("created_at"), OriginalType: "time.Time", GoType: "time.Time", PreventValidation: true})
-	m.addAttribute(attribute{Name: flect.New("updated_at"), OriginalType: "time.Time", GoType: "time.Time", PreventValidation: true})
+	m.addAttribute(attribute{Name: flect.New("created_at"), OriginalType: "time.Time", GoType: "time.Time", PreventValidation: true, StructTag: structTag})
+	m.addAttribute(attribute{Name: flect.New("updated_at"), OriginalType: "time.Time", GoType: "time.Time", PreventValidation: true, StructTag: structTag})
 
 	return m, nil
 }

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -30,6 +30,7 @@ type model struct {
 	attributesCache       map[string]struct{}
 	Attributes            []attribute
 	ValidatableAttributes []attribute
+	StructTag             string
 
 	HasNulls  bool
 	HasUUID   bool
@@ -49,8 +50,8 @@ func (m model) Generate() error {
 	ctx["test_package_name"] = m.testPkgName()
 
 	ctx["char"] = m.Name.Char()
-	ctx["encoding_type"] = structTag
-	ctx["encoding_type_char"] = strings.ToLower(string([]byte(structTag)[0]))
+	ctx["encoding_type"] = m.StructTag
+	ctx["encoding_type_char"] = nflect.Char(m.StructTag)
 
 	fname := filepath.Join(m.Package, m.Name.File(".go").String())
 	g.Add(makr.NewFile(fname, modelTemplate))
@@ -214,7 +215,7 @@ func (m model) GenerateSQLFromFizz(content string, f fizz.Translator) string {
 	return content
 }
 
-func newModel(name string) model {
+func newModel(name string, structTag string) (model, error) {
 	m := model{
 		Package:               "models",
 		Imports:               []string{"time", "github.com/gobuffalo/pop", "github.com/gobuffalo/validate"},
@@ -222,12 +223,22 @@ func newModel(name string) model {
 		Attributes:            []attribute{},
 		ValidatableAttributes: []attribute{},
 		attributesCache:       map[string]struct{}{},
+		StructTag:             structTag,
+	}
+
+	switch structTag {
+	case "json":
+		m.Imports = append(m.Imports, "encoding/json")
+	case "xml":
+		m.Imports = append(m.Imports, "encoding/xml")
+	default:
+		return model{}, errors.New("invalid struct tags (use xml or json)")
 	}
 
 	m.addAttribute(attribute{Name: flect.New("created_at"), OriginalType: "time.Time", GoType: "time.Time", PreventValidation: true})
 	m.addAttribute(attribute{Name: flect.New("updated_at"), OriginalType: "time.Time", GoType: "time.Time", PreventValidation: true})
 
-	return m
+	return m, nil
 }
 
 func fizzColType(s string) string {

--- a/soda/cmd/generate/model_test.go
+++ b/soda/cmd/generate/model_test.go
@@ -26,7 +26,8 @@ func Test_addAttribute(t *testing.T) {
 	for index, tcase := range cases {
 		t.Run(fmt.Sprintf("%v", index), func(tt *testing.T) {
 			r := require.New(tt)
-			m := newModel("car")
+			m, err := newModel("car", "json")
+			r.NoError(err)
 			a, err := newAttribute(tcase.AttrInput, &m)
 			r.NoError(err)
 			m.addAttribute(a)
@@ -50,7 +51,8 @@ func Test_addAttribute(t *testing.T) {
 func Test_model_addID(t *testing.T) {
 	r := require.New(t)
 
-	m := newModel("car")
+	m, err := newModel("car", "json")
+	r.NoError(err)
 	m.addID()
 
 	r.Equal(m.HasID, true)
@@ -58,7 +60,8 @@ func Test_model_addID(t *testing.T) {
 	r.Equal(m.Attributes[0].Name.String(), "id")
 	r.Equal(string(m.Attributes[0].GoType), "uuid.UUID")
 
-	m = newModel("car")
+	m, err = newModel("car", "json")
+	r.NoError(err)
 	a, err := newAttribute("id:int", &m)
 	r.NoError(err)
 	err = m.addAttribute(a)
@@ -74,7 +77,8 @@ func Test_model_addID(t *testing.T) {
 func Test_model_addDuplicate(t *testing.T) {
 	r := require.New(t)
 
-	m := newModel("car")
+	m, err := newModel("car", "json")
+	r.NoError(err)
 	a, err := newAttribute("color:string", &m)
 	r.NoError(err)
 	err = m.addAttribute(a)
@@ -93,7 +97,8 @@ func Test_model_addDuplicate(t *testing.T) {
 
 func Test_testPkgName(t *testing.T) {
 	r := require.New(t)
-	m := newModel("car")
+	m, err := newModel("car", "json")
+	r.NoError(err)
 
 	r.Equal("models", m.testPkgName())
 


### PR DESCRIPTION
* Prevent global vars usage.
* Move struct tag check in model constructor.