### PR TITLE
Prevent migrate command to take any argument

### DIFF
--- a/soda/cmd/migrate.go
+++ b/soda/cmd/migrate.go
@@ -19,6 +19,9 @@ var migrateCmd = &cobra.Command{
 		return os.MkdirAll(migrationPath, 0766)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return errors.New("migrate command does not accept any argument")
+		}
 		mig, err := pop.NewFileMigrator(migrationPath, getConn())
 		if err != nil {
 			return errors.WithStack(err)

--- a/soda/cmd/root.go
+++ b/soda/cmd/root.go
@@ -32,7 +32,6 @@ var RootCmd = &cobra.Command{
 // Execute runs RunCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
`db migrate excans up` shouldn't work.