### PR TITLE
Revert breaking change introduced by #235

### DIFF
--- a/soda/cmd/drop.go
+++ b/soda/cmd/drop.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
-	"bufio"
 	"os"
 
 	"github.com/gobuffalo/pop"
@@ -12,7 +10,6 @@ import (
 )
 
 var all bool
-var confirmed bool
 
 var dropCmd = &cobra.Command{
 	Use:   "drop",
@@ -23,18 +20,6 @@ var dropCmd = &cobra.Command{
 			err = fmt.Errorf("no arguments allowed with the drop database command")
 			fmt.Println(err)
 			os.Exit(1)
-		}
-
-		if !confirmed {
-			reader := bufio.NewReader(os.Stdin)
-			fmt.Print("Do you really want to drop the database [y/N]? ")
-			r, _ := reader.ReadString('\n')
-			r = strings.TrimSpace(r)
-			if r != "y" && r != "Y" {
-				fmt.Println("Aborting due to lack of user confirmation.")
-				os.Exit(0)
-			}
-
 		}
 
 		if all {
@@ -54,6 +39,5 @@ var dropCmd = &cobra.Command{
 
 func init() {
 	dropCmd.Flags().BoolVarP(&all, "all", "a", false, "Drops all of the databases in the database.yml")
-	dropCmd.Flags().BoolVarP(&confirmed, "yes", "y", false, "Runs without asking the user for confirmation")
 	RootCmd.AddCommand(dropCmd)
 }


### PR DESCRIPTION
Drop command shouldn't need a confirmation, but we should help to prevent bad mistakes.