### PR TITLE
Require MySQL DSN to contain multiStatements=true

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -40,6 +40,11 @@ func (m *mysql) Details() *ConnectionDetails {
 func (m *mysql) URL() string {
 	deets := m.ConnectionDetails
 	if deets.URL != "" {
+		// Force multiStatements=true, migrations can fail otherwise.
+		if !strings.Contains(deets.URL, "multiStatements=true") {
+			log(logging.Warn, "multiStatements=true option is required to work with pop migrations. Please add it to the database URL in the config")
+			deets.URL += "&multiStatements=true"
+		}
 		return strings.TrimPrefix(deets.URL, "mysql://")
 	}
 	encoding := defaults.String(deets.Encoding, "utf8mb4_general_ci")

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -16,6 +16,6 @@ func Test_MySQL_URL(t *testing.T) {
 	r.NoError(err)
 
 	m := &mysql{ConnectionDetails: cd}
-	r.Equal("dbase:dbase@(dbase:dbase)/dbase?dbase=dbase", m.URL())
-	r.Equal("dbase:dbase@(dbase:dbase)/?dbase=dbase", m.urlWithoutDb())
+	r.Equal("dbase:dbase@(dbase:dbase)/dbase?dbase=dbase&multiStatements=true", m.URL())
+	r.Equal("dbase:dbase@(dbase:dbase)/?dbase=dbase&multiStatements=true", m.urlWithoutDb())
 }


### PR DESCRIPTION
This is required to run migrations. Fixes #250.