### PR TITLE
fixes broken model template

### DIFF
--- a/soda/cmd/generate/attribute.go
+++ b/soda/cmd/generate/attribute.go
@@ -20,6 +20,9 @@ type attribute struct {
 }
 
 func (a attribute) String() string {
+	if len(a.StructTag) == 0 {
+		a.StructTag = "json"
+	}
 	return fmt.Sprintf("\t%s %s `%s:\"%s\" db:\"%s\"`", a.Name.Pascalize(), a.GoType, a.StructTag, a.Name.Underscore(), a.Name.Underscore())
 }
 

--- a/soda/cmd/generate/attribute_test.go
+++ b/soda/cmd/generate/attribute_test.go
@@ -15,6 +15,10 @@ func Test_Attribute_String(t *testing.T) {
 		name string
 	}{
 		{
+			name: "id",
+			exp:  "\tID string `json:\"id\" db:\"id\"`",
+		},
+		{
 			name: "user_id",
 			exp:  "\tUserID string `json:\"user_id\" db:\"user_id\"`",
 		},

--- a/soda/cmd/generate/model_templates.go
+++ b/soda/cmd/generate/model_templates.go
@@ -38,7 +38,7 @@ func ({{.char}} *{{.model_name}}) Validate(tx *pop.Connection) (*validate.Errors
 	{{ if .model.ValidatableAttributes -}}
 	return validate.Validate(
 		{{ range $a := .model.ValidatableAttributes -}}
-		&validators.{{capitalize $a.GoType}}IsPresent{Field: {{$.char}}.{{$a.Name.Camelize}}, Name: "{{$a.Name.Camelize}}"},
+		&validators.{{capitalize $a.GoType}}IsPresent{Field: {{$.char}}.{{$a.Name.Pascalize}}, Name: "{{$a.Name.Pascalize}}"},
 		{{end -}}
 	), nil
 	{{ else -}}


### PR DESCRIPTION
When trying to figure out why https://github.com/gobuffalo/buffalo/pull/1346 was failing I found that the model template is producing a broken model.  

```bash
$ soda g model user name
```

## Expected output

```go
func (u *User) Validate(tx *pop.Connection) (*validate.Errors, error) {
	return validate.Validate(
		&validators.StringIsPresent{Field: u.Name, Name: "Name"},
	), nil
}
```

## Actual output:

```go
func (u *User) Validate(tx *pop.Connection) (*validate.Errors, error) {
	return validate.Validate(
		&validators.StringIsPresent{Field: u.name, Name: "name"},
	), nil
}
```