### PR TITLE
Query in support with slice args.

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -53,8 +53,8 @@ func Test_Where_In_Slice(t *testing.T) {
 	r := require.New(t)
 	transaction(func(tx *Connection) {
 		u1 := &Song{Title: "A"}
-		u2 := &Song{Title: "B"}
-		u3 := &Song{Title: "C"}
+		u2 := &Song{Title: "A"}
+		u3 := &Song{Title: "A"}
 		err := tx.Create(u1)
 		r.NoError(err)
 		err = tx.Create(u2)
@@ -63,7 +63,7 @@ func Test_Where_In_Slice(t *testing.T) {
 		r.NoError(err)
 
 		songs := []Song{}
-		err = tx.Where("id in (?)", []uuid.UUID{u1.ID, u3.ID}).All(&songs)
+		err = tx.Where("id in (?)", []uuid.UUID{u1.ID, u3.ID}).Where("title = ?", "A").All(&songs)
 		r.NoError(err)
 		r.Len(songs, 2)
 	})

--- a/query_test.go
+++ b/query_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gobuffalo/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,6 +44,26 @@ func Test_Where_In(t *testing.T) {
 
 		songs := []Song{}
 		err = tx.Where("id in (?)", u1.ID, u3.ID).All(&songs)
+		r.NoError(err)
+		r.Len(songs, 2)
+	})
+}
+
+func Test_Where_In_Slice(t *testing.T) {
+	r := require.New(t)
+	transaction(func(tx *Connection) {
+		u1 := &Song{Title: "A"}
+		u2 := &Song{Title: "B"}
+		u3 := &Song{Title: "C"}
+		err := tx.Create(u1)
+		r.NoError(err)
+		err = tx.Create(u2)
+		r.NoError(err)
+		err = tx.Create(u3)
+		r.NoError(err)
+
+		songs := []Song{}
+		err = tx.Where("id in (?)", []uuid.UUID{u1.ID, u3.ID}).All(&songs)
 		r.NoError(err)
 		r.Len(songs, 2)
 	})

--- a/sql_builder.go
+++ b/sql_builder.go
@@ -88,9 +88,10 @@ func (sq *sqlBuilder) compile() {
 		}
 
 		if inRegex.MatchString(sq.sql) {
-			s, _, err := sqlx.In(sq.sql, sq.Args())
+			s, args, err := sqlx.In(sq.sql, sq.Args()...)
 			if err == nil {
 				sq.sql = s
+				sq.args = args
 			}
 		}
 		sq.sql = sq.Query.Connection.Dialect.TranslateSQL(sq.sql)


### PR DESCRIPTION
This PR allows to pass an slice for `In` even when using multiple wildcards in `Where` calls. This is related with an old issue reported in https://github.com/markbates/pop/issues/123