### PR TITLE
improvement of cockroach dialect and some fixes

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ func Test_LoadsConnectionsFromConfig(t *testing.T) {
 	r := require.New(t)
 
 	conns := Connections
-	r.Equal(5, len(conns))
+	r.Equal(6, len(conns))
 }
 
 func Test_AddLookupPaths(t *testing.T) {

--- a/connection_details.go
+++ b/connection_details.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	_mysql "github.com/go-sql-driver/mysql"
+	"github.com/gobuffalo/pop/logging"
 	"github.com/markbates/going/defaults"
 	"github.com/markbates/oncer"
 	"github.com/pkg/errors"
@@ -39,80 +40,103 @@ type ConnectionDetails struct {
 	// Defaults to 0 "unlimited". See https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 	IdlePool int
 	Options  map[string]string
+	// Query string encoded options from URL. Example: "sslmode=disable"
+	RawOptions string
 }
 
-var dialectX = regexp.MustCompile(`\s+://`)
+var dialectX = regexp.MustCompile(`\S+://`)
+
+// overrideWithURL parses and overrides all connection details
+// with values form URL except Dialect.
+func (cd *ConnectionDetails) overrideWithURL() error {
+	ul := cd.URL
+	if cd.Dialect != "" && !dialectX.MatchString(ul) {
+		ul = cd.Dialect + "://" + ul
+	}
+
+	u, err := url.Parse(ul)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't parse %s", ul)
+	}
+
+	//! dialect should not be overrided here (especially for cockroach)
+	if cd.Dialect == "" {
+		cd.Dialect = u.Scheme
+	}
+
+	// warning message is required to prevent confusion
+	// even though this behavior was documented.
+	if cd.Database+cd.Host+cd.Port+cd.User+cd.Password != "" {
+		log(logging.Warn, "One or more of connection parameters are specified in database.yml. Override them with values in URL.")
+	}
+
+	if strings.HasPrefix(cd.Dialect, "sqlite") {
+		cd.Database = u.Path
+		return nil
+	} else if strings.HasPrefix(cd.Dialect, "mysql") {
+		return cd.overrideWithMySQLURL()
+	}
+
+	cd.Database = strings.TrimPrefix(u.Path, "/")
+
+	hp := strings.Split(u.Host, ":")
+	cd.Host = hp[0]
+	if len(hp) > 1 {
+		cd.Port = hp[1]
+	}
+
+	if u.User != nil {
+		cd.User = u.User.Username()
+		cd.Password, _ = u.User.Password()
+	}
+	cd.RawOptions = u.RawQuery
+
+	return nil
+}
+
+func (cd *ConnectionDetails) overrideWithMySQLURL() error {
+	// parse and verify whether URL is supported by underlying driver or not.
+	cfg, err := _mysql.ParseDSN(strings.TrimPrefix(cd.URL, "mysql://"))
+	if err != nil {
+		return errors.Wrapf(err, "the URL '%s' is not supported by MySQL driver", cd.URL)
+	}
+
+	cd.User = cfg.User
+	cd.Password = cfg.Passwd
+	cd.Database = cfg.DBName
+	cd.Encoding = defaults.String(cfg.Collation, "utf8_general_ci")
+	addr := strings.TrimSuffix(strings.TrimPrefix(cfg.Addr, "("), ")")
+	if cfg.Net == "unix" {
+		cd.Port = "socket"
+		cd.Host = addr
+	} else {
+		tmp := strings.Split(addr, ":")
+		cd.Host = tmp[0]
+		if len(tmp) > 1 {
+			cd.Port = tmp[1]
+		}
+	}
+
+	return nil
+}
 
 // Finalize cleans up the connection details by normalizing names,
 // filling in default values, etc...
 func (cd *ConnectionDetails) Finalize() error {
 	cd.Dialect = normalizeSynonyms(cd.Dialect)
 	if cd.URL != "" {
-		ul := cd.URL
-		if cd.Dialect != "" {
-			if !dialectX.MatchString(ul) {
-				ul = cd.Dialect + "://" + ul
-			}
+		if err := cd.overrideWithURL(); err != nil {
+			return err
 		}
-		cd.Database = cd.URL
-		if cd.Dialect != "sqlite3" {
-			u, err := url.Parse(ul)
-			if err != nil {
-				return errors.Wrapf(err, "couldn't parse %s", ul)
-			}
-			cd.Dialect = u.Scheme
-			cd.Database = u.Path
-
-			hp := strings.Split(u.Host, ":")
-			cd.Host = hp[0]
-			if len(hp) > 1 {
-				cd.Port = hp[1]
-			}
-
-			if u.User != nil {
-				cd.User = u.User.Username()
-				cd.Password, _ = u.User.Password()
-			}
-		}
-
 	}
+
 	switch cd.Dialect {
 	case "postgres":
 		cd.Port = defaults.String(cd.Port, "5432")
-		cd.Database = strings.TrimPrefix(cd.Database, "/")
 	case "cockroach":
 		cd.Port = defaults.String(cd.Port, "26257")
-		cd.Database = strings.TrimPrefix(cd.Database, "/")
 	case "mysql":
-		// parse and verify whether URL is supported by underlying driver or not.
-		if cd.URL != "" {
-			cfg, err := _mysql.ParseDSN(strings.TrimPrefix(cd.URL, "mysql://"))
-			if err != nil {
-				return errors.Wrap(err, "the URL is not supported by MySQL driver")
-			}
-			cd.User = cfg.User
-			cd.Password = cfg.Passwd
-			cd.Database = cfg.DBName
-			cd.Encoding = defaults.String(cfg.Collation, "utf8_general_ci")
-			addr := strings.TrimSuffix(strings.TrimPrefix(cfg.Addr, "("), ")")
-			if cfg.Net == "unix" {
-				cd.Port = "socket"
-				cd.Host = addr
-			} else {
-				tmp := strings.Split(addr, ":")
-				switch len(tmp) {
-				case 1:
-					cd.Host = tmp[0]
-					cd.Port = "3306"
-				case 2:
-					cd.Host = tmp[0]
-					cd.Port = tmp[1]
-				}
-			}
-		} else {
-			cd.Port = defaults.String(cd.Port, "3306")
-			cd.Database = strings.TrimPrefix(cd.Database, "/")
-		}
+		cd.Port = defaults.String(cd.Port, "3306")
 	case "sqlite3":
 		// Nothing more to do here
 	default:

--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -42,6 +42,22 @@ func Test_ConnectionDetails_Finalize_MySQL_DSN(t *testing.T) {
 	r.Equal("database", cd.Database)
 }
 
+func Test_ConnectionDetails_Finalize_Cockroach(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "cockroach",
+		URL:     "postgres://user:pass@host:port/database?sslmode=require&sslrootcert=certs/ca.crt&sslkey=certs/client.key&sslcert=certs/client.crt",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.Equal("cockroach", cd.Dialect)
+	r.Equal("database", cd.Database)
+	r.Equal("host", cd.Host)
+	r.Equal("port", cd.Port)
+	r.Equal("user", cd.User)
+	r.Equal("pass", cd.Password)
+}
+
 func Test_ConnectionDetails_Finalize_MySQL_DSN_collation(t *testing.T) {
 	r := require.New(t)
 
@@ -131,4 +147,35 @@ func Test_ConnectionDetails_Finalize_SQLite(t *testing.T) {
 	r.Equal(cd.Password, "")
 	r.Equal(cd.Port, "")
 	r.Equal(cd.User, "")
+}
+
+func Test_ConnectionDetails_Finalize_SQLite_with_Dialect(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "sqlite",
+		URL:     "sqlite3:///tmp/foo.db",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.Equal("/tmp/foo.db", cd.Database)
+	r.Equal("sqlite3", cd.Dialect)
+	r.Equal("", cd.Host)
+	r.Equal("", cd.Password)
+	r.Equal("", cd.Port)
+	r.Equal("", cd.User)
+}
+func Test_ConnectionDetails_Finalize_SQLite_without_URL(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect:  "sqlite",
+		Database: "./foo.db",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.Equal("./foo.db", cd.Database)
+	r.Equal("sqlite3", cd.Dialect)
+	r.Equal("", cd.Host)
+	r.Equal("", cd.Password)
+	r.Equal("", cd.Port)
+	r.Equal("", cd.User)
 }

--- a/database.yml
+++ b/database.yml
@@ -28,6 +28,12 @@ cockroach:
   port: {{ envOr "COCKROACH_PORT" "26257"  }}
   user: {{ envOr "COCKROACH_USER" "root"  }}
   password: {{ envOr "COCKROACH_PASSWORD" ""  }}
+  options:
+    sslmode: disable
+
+cockroach_ssl:
+  dialect: "cockroach"
+  url: "postgres://root@localhost:26257/pop_test?sslmode=require&sslrootcert=./certs/ca.crt&sslkey=./certs/client.root.key&sslcert=./certs/client.root.crt"
 
 sqlite:
   dialect: "sqlite3"

--- a/dialect_cockroach_test.go
+++ b/dialect_cockroach_test.go
@@ -1,0 +1,39 @@
+package pop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Cockroach_URL_Raw(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "cockroach",
+		URL:     "scheme://user:pass@host:port/database?option1=value1",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	m := &cockroach{ConnectionDetails: cd}
+	r.Equal("scheme://user:pass@host:port/database?option1=value1", m.URL())
+	r.Equal("postgres://user:pass@host:port/?option1=value1", m.urlWithoutDb())
+}
+func Test_Cockroach_URL_Build(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect:  "cockroach",
+		Database: "database",
+		Host:     "host",
+		Port:     "port",
+		User:     "user",
+		Password: "pass",
+		Options: map[string]string{
+			"option1": "value1",
+		},
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	m := &cockroach{ConnectionDetails: cd}
+	r.Equal("postgres://user:pass@host:port/database?application_name=cockroach&option1=value1", m.URL())
+	r.Equal("postgres://user:pass@host:port/?application_name=cockroach&option1=value1", m.urlWithoutDb())
+}

--- a/executors_test.go
+++ b/executors_test.go
@@ -757,15 +757,11 @@ func Test_TruncateAll(t *testing.T) {
 		ctx, err := tx.Count("users")
 		r.NoError(err)
 		r.Equal(count+1, ctx)
-	})
 
-	transaction(func(tx *Connection) {
-		r := require.New(t)
-
-		err := tx.TruncateAll()
+		err = tx.TruncateAll()
 		r.NoError(err)
 
-		ctx, _ := tx.Count("users")
+		ctx, _ = tx.Count("users")
 		r.Equal(count, ctx)
 	})
 }

--- a/pop_test.go
+++ b/pop_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gobuffalo/pop/logging"
 	"github.com/gobuffalo/pop/nulls"
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
@@ -46,6 +47,7 @@ func init() {
 
 	var err error
 	PDB, err = Connect(dialect)
+	log(logging.Info, "Run test with dialect %v", dialect)
 	if err != nil {
 		stdlog.Panic(err)
 	}


### PR DESCRIPTION
Hi @markbates, @stanislas-m, and all!

Since my recent PR for improving Cockroach dialect(#271) are not merged smoothly, (maybe affected by recent Github failure?) so I wrote it again against current `development` branch.

This includes:
* support secure mode configuration with options without `url`. (can add any options)
* fixed `urlWithoutDb()` can handle secure mode with options.
* bugfix and clean up of `connection_details.go`.
* added test cases for above changes.

Additionally, @eduDorus reported a bug on the cockroach dialect (https://github.com/gobuffalo/buffalo/issues/1417)
* fixed `TrucateAll()` can support both v1 and v2 of Cockroachdb.
* fixed test case for `TrucateAll()`.

Please check this.