### PR TITLE
connection details cleanup

### DIFF
--- a/connection_details.go
+++ b/connection_details.go
@@ -112,7 +112,14 @@ func (cd *ConnectionDetails) Finalize() error {
 	if fin, ok := finalizer[cd.Dialect]; ok {
 		fin(cd)
 	}
-	return nil
+
+	if DialectSupported(cd.Dialect) {
+		if cd.Database != "" || cd.URL != "" {
+			return nil
+		}
+		return errors.New("no database or URL specified")
+	}
+	return errors.Errorf("unsupported dialect '%v'", cd.Dialect)
 }
 
 // Parse cleans up the connection details by normalizing names,

--- a/connection_details.go
+++ b/connection_details.go
@@ -1,6 +1,7 @@
 package pop
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -97,6 +98,11 @@ func (cd *ConnectionDetails) withURL() error {
 // filling in default values, etc...
 func (cd *ConnectionDetails) Finalize() error {
 	cd.Dialect = normalizeSynonyms(cd.Dialect)
+
+	if cd.Options == nil { // for safety
+		cd.Options = make(map[string]string)
+	}
+
 	if cd.URL != "" {
 		if err := cd.withURL(); err != nil {
 			return err
@@ -138,4 +144,17 @@ func (cd *ConnectionDetails) RetryLimit() int {
 // MigrationTableName returns the name of the table to track migrations
 func (cd *ConnectionDetails) MigrationTableName() string {
 	return defaults.String(cd.Options["migration_table_name"], "schema_migration")
+}
+
+// OptionsString returns URL parameter encoded string from options.
+func (cd *ConnectionDetails) OptionsString(s string) string {
+	if cd.RawOptions != "" {
+		return cd.RawOptions
+	}
+	if cd.Options != nil {
+		for k, v := range cd.Options {
+			s = fmt.Sprintf("%s&%s=%s", s, k, v)
+		}
+	}
+	return strings.TrimLeft(s, "&")
 }

--- a/connection_details.go
+++ b/connection_details.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	_mysql "github.com/go-sql-driver/mysql"
 	"github.com/gobuffalo/pop/logging"
 	"github.com/markbates/going/defaults"
 	"github.com/markbates/oncer"
@@ -46,14 +45,14 @@ type ConnectionDetails struct {
 
 var dialectX = regexp.MustCompile(`\S+://`)
 
-// overrideWithURL parses and overrides all connection details
-// with values form URL except Dialect.
-func (cd *ConnectionDetails) overrideWithURL() error {
+// withURL parses and overrides all connection details with values
+// from standard URL except Dialect. It also calls dialect specific
+// URL parser if exists.
+func (cd *ConnectionDetails) withURL() error {
 	ul := cd.URL
 	if cd.Dialect != "" && !dialectX.MatchString(ul) {
 		ul = cd.Dialect + "://" + ul
 	}
-
 	u, err := url.Parse(ul)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't parse %s", ul)
@@ -61,20 +60,20 @@ func (cd *ConnectionDetails) overrideWithURL() error {
 
 	//! dialect should not be overrided here (especially for cockroach)
 	if cd.Dialect == "" {
-		cd.Dialect = u.Scheme
+		cd.Dialect = normalizeSynonyms(u.Scheme)
+	}
+	if !DialectSupported(cd.Dialect) {
+		return errors.Errorf("unsupported dialect '%v'", cd.Dialect)
 	}
 
 	// warning message is required to prevent confusion
 	// even though this behavior was documented.
 	if cd.Database+cd.Host+cd.Port+cd.User+cd.Password != "" {
-		log(logging.Warn, "One or more of connection parameters are specified in database.yml. Override them with values in URL.")
+		log(logging.Warn, "One or more of connection details are specified in database.yml. Override them with values in URL.")
 	}
 
-	if strings.HasPrefix(cd.Dialect, "sqlite") {
-		cd.Database = u.Path
-		return nil
-	} else if strings.HasPrefix(cd.Dialect, "mysql") {
-		return cd.overrideWithMySQLURL()
+	if up, ok := urlParser[cd.Dialect]; ok {
+		return up(cd)
 	}
 
 	cd.Database = strings.TrimPrefix(u.Path, "/")
@@ -94,53 +93,18 @@ func (cd *ConnectionDetails) overrideWithURL() error {
 	return nil
 }
 
-func (cd *ConnectionDetails) overrideWithMySQLURL() error {
-	// parse and verify whether URL is supported by underlying driver or not.
-	cfg, err := _mysql.ParseDSN(strings.TrimPrefix(cd.URL, "mysql://"))
-	if err != nil {
-		return errors.Wrapf(err, "the URL '%s' is not supported by MySQL driver", cd.URL)
-	}
-
-	cd.User = cfg.User
-	cd.Password = cfg.Passwd
-	cd.Database = cfg.DBName
-	cd.Encoding = defaults.String(cfg.Collation, "utf8_general_ci")
-	addr := strings.TrimSuffix(strings.TrimPrefix(cfg.Addr, "("), ")")
-	if cfg.Net == "unix" {
-		cd.Port = "socket"
-		cd.Host = addr
-	} else {
-		tmp := strings.Split(addr, ":")
-		cd.Host = tmp[0]
-		if len(tmp) > 1 {
-			cd.Port = tmp[1]
-		}
-	}
-
-	return nil
-}
-
 // Finalize cleans up the connection details by normalizing names,
 // filling in default values, etc...
 func (cd *ConnectionDetails) Finalize() error {
 	cd.Dialect = normalizeSynonyms(cd.Dialect)
 	if cd.URL != "" {
-		if err := cd.overrideWithURL(); err != nil {
+		if err := cd.withURL(); err != nil {
 			return err
 		}
 	}
 
-	switch cd.Dialect {
-	case "postgres":
-		cd.Port = defaults.String(cd.Port, "5432")
-	case "cockroach":
-		cd.Port = defaults.String(cd.Port, "26257")
-	case "mysql":
-		cd.Port = defaults.String(cd.Port, "3306")
-	case "sqlite3":
-		// Nothing more to do here
-	default:
-		return errors.Errorf("unknown dialect %s", cd.Dialect)
+	if fin, ok := finalizer[cd.Dialect]; ok {
+		fin(cd)
 	}
 	return nil
 }

--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -15,12 +15,12 @@ func Test_ConnectionDetails_Finalize(t *testing.T) {
 	err := cd.Finalize()
 	r.NoError(err)
 
-	r.Equal(cd.Database, "database")
-	r.Equal(cd.Dialect, "postgres")
-	r.Equal(cd.Host, "host")
-	r.Equal(cd.Password, "pass")
-	r.Equal(cd.Port, "port")
-	r.Equal(cd.User, "user")
+	r.Equal("database", cd.Database)
+	r.Equal("postgres", cd.Dialect)
+	r.Equal("host", cd.Host)
+	r.Equal("pass", cd.Password)
+	r.Equal("port", cd.Port)
+	r.Equal("user", cd.User)
 }
 
 func Test_ConnectionDetails_Finalize_MySQL_DSN(t *testing.T) {
@@ -81,7 +81,7 @@ func Test_ConnectionDetails_Finalize_MySQL_DSN_collation(t *testing.T) {
 		r.Equal("host", cd.Host)
 		r.Equal("port", cd.Port)
 		r.Equal("database", cd.Database)
-		r.Equal("utf8mb4_general_ci", cd.Encoding)
+		r.Equal("utf8mb4_general_ci", cd.Options["collation"])
 	}
 }
 

--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -123,10 +123,28 @@ func Test_ConnectionDetails_Finalize_MySQL_DSN_Socket(t *testing.T) {
 	r.Equal("socket", cd.Database)
 }
 
-func Test_ConnectionDetails_Finalize_UnknownDialect(t *testing.T) {
+func Test_ConnectionDetails_Finalize_UnknownSchemeURL(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
 		URL: "unknown://user:pass@host:port/database",
+	}
+	err := cd.Finalize()
+	r.Error(err)
+}
+
+func Test_ConnectionDetails_Finalize_UnknownDialect(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "unknown",
+	}
+	err := cd.Finalize()
+	r.Error(err)
+}
+
+func Test_ConnectionDetails_Finalize_NoDB_NoURL(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "sqlite3",
 	}
 	err := cd.Finalize()
 	r.Error(err)

--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -81,7 +81,7 @@ func Test_ConnectionDetails_Finalize_MySQL_DSN_collation(t *testing.T) {
 		r.Equal("host", cd.Host)
 		r.Equal("port", cd.Port)
 		r.Equal("database", cd.Database)
-		r.Equal("utf8mb4_general_ci", cd.Options["collation"])
+		r.Equal("utf8mb4_general_ci", cd.Encoding)
 	}
 }
 

--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -132,7 +132,7 @@ func Test_ConnectionDetails_Finalize_UnknownDialect(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_ConnectionDetails_Finalize_SQLite(t *testing.T) {
+func Test_ConnectionDetails_Finalize_SQLite_URL_Only(t *testing.T) {
 	r := require.New(t)
 
 	cd := &ConnectionDetails{
@@ -140,16 +140,63 @@ func Test_ConnectionDetails_Finalize_SQLite(t *testing.T) {
 	}
 	err := cd.Finalize()
 	r.NoError(err)
-
-	r.Equal(cd.Database, "/tmp/foo.db")
-	r.Equal(cd.Dialect, "sqlite3")
-	r.Equal(cd.Host, "")
-	r.Equal(cd.Password, "")
-	r.Equal(cd.Port, "")
-	r.Equal(cd.User, "")
+	r.Equal("sqlite3", cd.Dialect, "given dialect: N/A")
+	r.Equal("/tmp/foo.db", cd.Database, "given url: sqlite3:///tmp/foo.db")
+	r.Equal("", cd.Host)
+	r.Equal("", cd.Password)
+	r.Equal("", cd.Port)
+	r.Equal("", cd.User)
 }
 
-func Test_ConnectionDetails_Finalize_SQLite_with_Dialect(t *testing.T) {
+func Test_ConnectionDetails_Finalize_SQLite_SynURL_Only(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		URL: "sqlite:///tmp/foo.db",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.Equal("sqlite3", cd.Dialect, "given dialect: N/A")
+	r.Equal("/tmp/foo.db", cd.Database, "given url: sqlite:///tmp/foo.db")
+	r.Equal("", cd.Host)
+	r.Equal("", cd.Password)
+	r.Equal("", cd.Port)
+	r.Equal("", cd.User)
+}
+
+func Test_ConnectionDetails_Finalize_SQLite_Dialect_URL(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "sqlite3",
+		URL:     "sqlite3:///tmp/foo.db",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.Equal("sqlite3", cd.Dialect, "given dialect: sqlite3")
+	r.Equal("/tmp/foo.db", cd.Database, "given url: sqlite3:///tmp/foo.db")
+	r.Equal("", cd.Host)
+	r.Equal("", cd.Password)
+	r.Equal("", cd.Port)
+	r.Equal("", cd.User)
+}
+
+func Test_ConnectionDetails_Finalize_SQLite_Dialect_SynURL(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "sqlite3",
+		URL:     "sqlite:///tmp/foo.db",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.Equal("sqlite3", cd.Dialect, "given dialect: sqlite3")
+	r.Equal("/tmp/foo.db", cd.Database, "given url: sqlite:///tmp/foo.db")
+	r.Equal("", cd.Host)
+	r.Equal("", cd.Password)
+	r.Equal("", cd.Port)
+	r.Equal("", cd.User)
+}
+
+func Test_ConnectionDetails_Finalize_SQLite_Synonym_URL(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
 		Dialect: "sqlite",
@@ -157,25 +204,40 @@ func Test_ConnectionDetails_Finalize_SQLite_with_Dialect(t *testing.T) {
 	}
 	err := cd.Finalize()
 	r.NoError(err)
-	r.Equal("/tmp/foo.db", cd.Database)
-	r.Equal("sqlite3", cd.Dialect)
+	r.Equal("sqlite3", cd.Dialect, "given dialect: sqlite")
+	r.Equal("/tmp/foo.db", cd.Database, "given url: sqlite3:///tmp/foo.db")
 	r.Equal("", cd.Host)
 	r.Equal("", cd.Password)
 	r.Equal("", cd.Port)
 	r.Equal("", cd.User)
 }
 
-func Test_ConnectionDetails_Finalize_SQLite_without_URL(t *testing.T) {
+func Test_ConnectionDetails_Finalize_SQLite_Synonym_SynURL(t *testing.T) {
 	r := require.New(t)
+	cd := &ConnectionDetails{
+		Dialect: "sqlite",
+		URL:     "sqlite:///tmp/foo.db",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.Equal("sqlite3", cd.Dialect, "given dialect: sqlite")
+	r.Equal("/tmp/foo.db", cd.Database, "given url: sqlite:///tmp/foo.db")
+	r.Equal("", cd.Host)
+	r.Equal("", cd.Password)
+	r.Equal("", cd.Port)
+	r.Equal("", cd.User)
+}
 
+func Test_ConnectionDetails_Finalize_SQLite_Synonym_Path(t *testing.T) {
+	r := require.New(t)
 	cd := &ConnectionDetails{
 		Dialect:  "sqlite",
 		Database: "./foo.db",
 	}
 	err := cd.Finalize()
 	r.NoError(err)
-	r.Equal("./foo.db", cd.Database)
-	r.Equal("sqlite3", cd.Dialect)
+	r.Equal("sqlite3", cd.Dialect, "given dialect: sqlite")
+	r.Equal("./foo.db", cd.Database, "given database: ./foo.db")
 	r.Equal("", cd.Host)
 	r.Equal("", cd.Password)
 	r.Equal("", cd.Port)

--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -18,10 +18,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+const nameCockroach = "cockroach"
+const portCockroach = "26257"
+
 func init() {
-	AvailableDialects = append(AvailableDialects, "cockroach")
-	dialectSynonyms["cockroachdb"] = "cockroach"
-	dialectSynonyms["crdb"] = "cockroach"
+	AvailableDialects = append(AvailableDialects, nameCockroach)
+	dialectSynonyms["cockroachdb"] = nameCockroach
+	dialectSynonyms["crdb"] = nameCockroach
+	finalizer[nameCockroach] = finalizerCockroach
 }
 
 var _ dialect = &cockroach{}
@@ -43,7 +47,7 @@ type cockroach struct {
 }
 
 func (p *cockroach) Name() string {
-	return "cockroach"
+	return nameCockroach
 }
 
 func (p *cockroach) Details() *ConnectionDetails {
@@ -270,4 +274,8 @@ func newCockroach(deets *ConnectionDetails) dialect {
 		mu:                sync.Mutex{},
 	}
 	return cd
+}
+
+func finalizerCockroach(cd *ConnectionDetails) {
+	cd.Port = defaults.String(cd.Port, portCockroach)
 }

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -99,22 +99,3 @@ func Test_MySQL_User_Defined_Options(t *testing.T) {
 	r.Contains(m.urlWithoutDb(), "readTimeout=1h")
 	r.Contains(m.urlWithoutDb(), "collation=utf8")
 }
-
-// preserve this test case while deprecated code alives
-func Test_MySQL_Deprecated(t *testing.T) {
-	r := require.New(t)
-
-	cd := &ConnectionDetails{
-		Dialect:  "mysql",
-		Database: "base",
-		Host:     "host",
-		Port:     "port",
-		User:     "user",
-		Password: "pass",
-		Encoding: "myEncoding",
-	}
-	err := cd.Finalize()
-	r.NoError(err)
-	r.NotNil(cd.Options)
-	r.Equal("myEncoding", cd.Options["collation"])
-}

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -1,21 +1,120 @@
 package pop
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func Test_MySQL_URL(t *testing.T) {
+func Test_MySQL_URL_As_Is(t *testing.T) {
 	r := require.New(t)
 
 	cd := &ConnectionDetails{
-		URL: "mysql://dbase:dbase@(dbase:dbase)/dbase?dbase=dbase",
+		URL: "mysql://user:pass@(host:port)/dbase?opt=value",
 	}
 	err := cd.Finalize()
 	r.NoError(err)
 
 	m := &mysql{ConnectionDetails: cd}
-	r.Equal("dbase:dbase@(dbase:dbase)/dbase?dbase=dbase&multiStatements=true", m.URL())
-	r.Equal("dbase:dbase@(dbase:dbase)/?dbase=dbase&multiStatements=true", m.urlWithoutDb())
+	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
+	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+}
+
+func Test_MySQL_withURL(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		Database: "xx",
+		Host:     "xx",
+		Port:     "xx",
+		User:     "xx",
+		Password: "xx",
+		URL:      "mysql://user:pass@(host:port)/dbase?opt=value",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+
+	m := &mysql{ConnectionDetails: cd}
+	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
+	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+}
+
+func Test_MySQL_Default_Options(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		Dialect:  "mysql",
+		Database: "base",
+		Host:     "host",
+		Port:     "port",
+		User:     "user",
+		Password: "pass",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+
+	m := &mysql{ConnectionDetails: cd}
+	r.True(strings.HasPrefix(m.URL(), "user:pass@(host:port)/base?"))
+	r.Contains(m.URL(), "multiStatements=true")
+	r.Contains(m.URL(), "parseTime=true")
+	r.Contains(m.URL(), "readTimeout=1s")
+	r.Contains(m.URL(), "collation=utf8mb4_general_ci")
+	r.True(strings.HasPrefix(m.urlWithoutDb(), "user:pass@(host:port)/?"))
+	r.Contains(m.urlWithoutDb(), "multiStatements=true")
+	r.Contains(m.urlWithoutDb(), "parseTime=true")
+	r.Contains(m.urlWithoutDb(), "readTimeout=1s")
+	r.Contains(m.urlWithoutDb(), "collation=utf8mb4_general_ci")
+}
+
+func Test_MySQL_User_Defined_Options(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		Dialect:  "mysql",
+		Database: "base",
+		Host:     "host",
+		Port:     "port",
+		User:     "user",
+		Password: "pass",
+		Options: map[string]string{
+			"multiStatements": "false",
+			"parseTime":       "false",
+			"readTimeout":     "1h",
+			"collation":       "utf8",
+		},
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+
+	m := &mysql{ConnectionDetails: cd}
+	r.True(strings.HasPrefix(m.URL(), "user:pass@(host:port)/base?"))
+	r.Contains(m.URL(), "multiStatements=false")
+	r.Contains(m.URL(), "parseTime=false")
+	r.Contains(m.URL(), "readTimeout=1h")
+	r.Contains(m.URL(), "collation=utf8")
+	r.True(strings.HasPrefix(m.urlWithoutDb(), "user:pass@(host:port)/?"))
+	r.Contains(m.urlWithoutDb(), "multiStatements=false")
+	r.Contains(m.urlWithoutDb(), "parseTime=false")
+	r.Contains(m.urlWithoutDb(), "readTimeout=1h")
+	r.Contains(m.urlWithoutDb(), "collation=utf8")
+}
+
+// preserve this test case while deprecated code alives
+func Test_MySQL_Deprecated(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		Dialect:  "mysql",
+		Database: "base",
+		Host:     "host",
+		Port:     "port",
+		User:     "user",
+		Password: "pass",
+		Encoding: "myEncoding",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	r.NotNil(cd.Options)
+	r.Equal("myEncoding", cd.Options["collation"])
 }

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -16,10 +16,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+const namePostgreSQL = "postgres"
+const portPostgreSQL = "5432"
+
 func init() {
-	AvailableDialects = append(AvailableDialects, "postgres")
-	dialectSynonyms["postgresql"] = "postgres"
-	dialectSynonyms["pg"] = "postgres"
+	AvailableDialects = append(AvailableDialects, namePostgreSQL)
+	dialectSynonyms["postgresql"] = namePostgreSQL
+	dialectSynonyms["pg"] = namePostgreSQL
+	finalizer[namePostgreSQL] = finalizerPostgreSQL
 }
 
 var _ dialect = &postgresql{}
@@ -31,7 +35,7 @@ type postgresql struct {
 }
 
 func (p *postgresql) Name() string {
-	return "postgres"
+	return namePostgreSQL
 }
 
 func (p *postgresql) Details() *ConnectionDetails {
@@ -196,6 +200,10 @@ func newPostgreSQL(deets *ConnectionDetails) dialect {
 		mu:                sync.Mutex{},
 	}
 	return cd
+}
+
+func finalizerPostgreSQL(cd *ConnectionDetails) {
+	cd.Port = defaults.String(cd.Port, portPostgreSQL)
 }
 
 const pgTruncate = `DO

--- a/pop.go
+++ b/pop.go
@@ -7,6 +7,12 @@ var AvailableDialects []string
 
 var dialectSynonyms = make(map[string]string)
 
+// map of dialect specific url parsers
+var urlParser = make(map[string]func(*ConnectionDetails) error)
+
+// map of dialect specific connection details finalizers
+var finalizer = make(map[string]func(*ConnectionDetails))
+
 // DialectSupported checks support for the given database dialect
 func DialectSupported(d string) bool {
 	for _, ad := range AvailableDialects {


### PR DESCRIPTION
Hi all,
I proposed #281 and I have no responses yet. Anyway, I tried to change some basic things to remove database engine specific stuff from connection details.

By this change, now:
* added two global maps for database specific URL parsers and finalizers.
* when `init()` for dialect was executed, it register database specific parser and finalizer if exist.
* original parser was rename to `withURL()` from `overrideWithURL()`.
* original parser does generic URL parsing and calling database specific parser.
* database specific parser does special URL handling for its driver/behavior.
* original finalizer in connection details controls the flow and call database specific finalizer.
* database specific finalizer does set default values, makes a database specific warnings,...
* all `switch`s for database engine specific works are removed.
* now `CD.Options map[string]string` can be used generally for building URL parameter.
  * by this, the user can add any of database-specific options as `yaml` style format.

Additionally,
* MySQL dialect is integrated with this style.
* Cockroach dialect was fixed in this concept already.
* Other dialects are not affected by this change but some code was added (finalizer or parser)

For the next step, I want to correct all test cases for `Finalize()` and dialects.

Am I drive to right direction?