### PR TITLE
fixed mysql dialect to use `options` instead of `encoding` and hardcoded values

### DIFF
--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -23,7 +23,7 @@ func Test_ConnectionDetails_Finalize(t *testing.T) {
 	r.Equal("user", cd.User)
 }
 
-func Test_ConnectionDetails_Finalize_MySQL_DSN(t *testing.T) {
+func Test_ConnectionDetails_Finalize_MySQL_Standard(t *testing.T) {
 	r := require.New(t)
 
 	url := "mysql://user:pass@(host:port)/database?param1=value1&param2=value2"
@@ -56,71 +56,6 @@ func Test_ConnectionDetails_Finalize_Cockroach(t *testing.T) {
 	r.Equal("port", cd.Port)
 	r.Equal("user", cd.User)
 	r.Equal("pass", cd.Password)
-}
-
-func Test_ConnectionDetails_Finalize_MySQL_DSN_collation(t *testing.T) {
-	r := require.New(t)
-
-	urls := []string{
-		"mysql://user:pass@(host:port)/database?collation=utf8mb4_general_ci",
-		"mysql://user:pass@(host:port)/database?collation=utf8mb4_general_ci&readTimeout=10s",
-		"mysql://user:pass@(host:port)/database?readTimeout=10s&collation=utf8mb4_general_ci",
-	}
-
-	for _, url := range urls {
-		cd := &ConnectionDetails{
-			URL: url,
-		}
-		err := cd.Finalize()
-		r.NoError(err)
-
-		r.Equal(url, cd.URL)
-		r.Equal("mysql", cd.Dialect)
-		r.Equal("user", cd.User)
-		r.Equal("pass", cd.Password)
-		r.Equal("host", cd.Host)
-		r.Equal("port", cd.Port)
-		r.Equal("database", cd.Database)
-		r.Equal("utf8mb4_general_ci", cd.Encoding)
-	}
-}
-
-func Test_ConnectionDetails_Finalize_MySQL_DSN_Protocol(t *testing.T) {
-	r := require.New(t)
-
-	url := "mysql://user:pass@tcp(host:port)/protocol"
-	cd := &ConnectionDetails{
-		URL: url,
-	}
-	err := cd.Finalize()
-	r.NoError(err)
-
-	r.Equal(url, cd.URL)
-	r.Equal("mysql", cd.Dialect)
-	r.Equal("user", cd.User)
-	r.Equal("pass", cd.Password)
-	r.Equal("host", cd.Host)
-	r.Equal("port", cd.Port)
-	r.Equal("protocol", cd.Database)
-}
-
-func Test_ConnectionDetails_Finalize_MySQL_DSN_Socket(t *testing.T) {
-	r := require.New(t)
-
-	url := "mysql://user:pass@unix(/path/to/socket)/socket"
-	cd := &ConnectionDetails{
-		URL: url,
-	}
-	err := cd.Finalize()
-	r.NoError(err)
-
-	r.Equal(url, cd.URL)
-	r.Equal("mysql", cd.Dialect)
-	r.Equal("user", cd.User)
-	r.Equal("pass", cd.Password)
-	r.Equal("/path/to/socket", cd.Host)
-	r.Equal("socket", cd.Port)
-	r.Equal("socket", cd.Database)
 }
 
 func Test_ConnectionDetails_Finalize_UnknownSchemeURL(t *testing.T) {

--- a/database.yml
+++ b/database.yml
@@ -6,8 +6,7 @@ mysql:
   user: {{ envOr "MYSQL_USER"  "root"  }}
   password: {{ envOr "MYSQL_PASSWORD"  "root"  }}
   options:
-    collation: utf8mb4_general_ci
-    multiStatements: true
+    readTimeout: 5s
 
 mysql_travis:
   dialect: "mysql"
@@ -17,8 +16,7 @@ mysql_travis:
   user: {{ envOr "MYSQL_USER"  "root"  }}
   password: {{ envOr "MYSQL_PASSWORD"  ""  }}
   options:
-    collation: utf8mb4_general_ci
-    multiStatements: true
+    readTimeout: 10s
 
 postgres:
   url: "postgres://postgres:postgres@localhost:5432/pop_test?sslmode=disable"

--- a/database.yml
+++ b/database.yml
@@ -5,7 +5,9 @@ mysql:
   port: {{ envOr "MYSQL_PORT" "3306"  }}
   user: {{ envOr "MYSQL_USER"  "root"  }}
   password: {{ envOr "MYSQL_PASSWORD"  "root"  }}
-  encoding: "utf8mb4_general_ci"
+  options:
+    collation: utf8mb4_general_ci
+    multiStatements: true
 
 mysql_travis:
   dialect: "mysql"
@@ -14,7 +16,9 @@ mysql_travis:
   port: {{ envOr "MYSQL_PORT" "3306"  }}
   user: {{ envOr "MYSQL_USER"  "root"  }}
   password: {{ envOr "MYSQL_PASSWORD"  ""  }}
-  encoding: "utf8mb4_general_ci"
+  options:
+    collation: utf8mb4_general_ci
+    multiStatements: true
 
 postgres:
   url: "postgres://postgres:postgres@localhost:5432/pop_test?sslmode=disable"

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -15,10 +15,12 @@ import (
 	"github.com/gobuffalo/pop/columns"
 	"github.com/gobuffalo/pop/logging"
 	"github.com/markbates/going/defaults"
+	"github.com/markbates/oncer"
 	"github.com/pkg/errors"
 )
 
 const nameMySQL = "mysql"
+const hostMySQL = "localhost"
 const portMySQL = "3306"
 
 func init() {
@@ -46,21 +48,27 @@ func (m *mysql) URL() string {
 	if cd.URL != "" {
 		return strings.TrimPrefix(cd.URL, "mysql://")
 	}
-	s := "%s:%s@(%s:%s)/%s?%s"
-	encOption := fmt.Sprintf("collation=%s", defaults.String(cd.Encoding, "utf8mb4_general_ci"))
-	return fmt.Sprintf(s, cd.User, cd.Password, cd.Host, cd.Port, cd.Database, cd.OptionsString(encOption))
+
+	user := fmt.Sprintf("%s:%s@", cd.User, cd.Password)
+	user = strings.Replace(user, ":@", "@", 1)
+	if user == "@" || strings.HasPrefix(user, ":") {
+		user = ""
+	}
+
+	addr := fmt.Sprintf("(%s:%s)", cd.Host, cd.Port)
+	// in case of unix domain socket, tricky.
+	// it is better to check Host is not valid inet address or has '/'.
+	if cd.Port == "socket" {
+		addr = fmt.Sprintf("unix(%s)", cd.Host)
+	}
+
+	s := "%s%s/%s?%s"
+	return fmt.Sprintf(s, user, addr, cd.Database, cd.OptionsString(""))
 }
 
 func (m *mysql) urlWithoutDb() string {
 	cd := m.ConnectionDetails
-	if cd.URL != "" {
-		// respect user's own URL definition (with options).
-		url := strings.TrimPrefix(cd.URL, "mysql://")
-		return strings.Replace(url, "/"+cd.Database+"?", "/?", 1)
-	}
-	s := "%s:%s@(%s:%s)/?%s"
-	encOption := fmt.Sprintf("collation=%s", defaults.String(cd.Encoding, "utf8mb4_general_ci"))
-	return fmt.Sprintf(s, cd.User, cd.Password, cd.Host, cd.Port, cd.OptionsString(encOption))
+	return strings.Replace(m.URL(), "/"+cd.Database+"?", "/?", 1)
 }
 
 func (m *mysql) MigrationURL() string {
@@ -95,7 +103,7 @@ func (m *mysql) CreateDB() error {
 		return errors.Wrapf(err, "error creating MySQL database %s", deets.Database)
 	}
 	defer db.Close()
-	encoding := defaults.String(deets.Encoding, "utf8mb4_general_ci")
+	encoding := defaults.String(deets.Options["collation"], "utf8mb4_general_ci")
 	query := fmt.Sprintf("CREATE DATABASE `%s` DEFAULT COLLATE `%s`", deets.Database, encoding)
 	log(logging.SQL, query)
 
@@ -193,13 +201,16 @@ func urlParserMySQL(cd *ConnectionDetails) error {
 	cd.User = cfg.User
 	cd.Password = cfg.Passwd
 	cd.Database = cfg.DBName
-	cd.Encoding = cfg.Collation
-	addr := strings.TrimSuffix(strings.TrimPrefix(cfg.Addr, "("), ")")
+	if cd.Options == nil { // prevent panic
+		cd.Options = make(map[string]string)
+	}
+	// NOTE: use cfg.Params if want to fill options with full parameters
+	cd.Options["collation"] = cfg.Collation
 	if cfg.Net == "unix" {
-		cd.Port = "socket"
-		cd.Host = addr
+		cd.Port = "socket" // trick. see: `URL()`
+		cd.Host = cfg.Addr
 	} else {
-		tmp := strings.Split(addr, ":")
+		tmp := strings.Split(cfg.Addr, ":")
 		cd.Host = tmp[0]
 		if len(tmp) > 1 {
 			cd.Port = tmp[1]
@@ -210,7 +221,9 @@ func urlParserMySQL(cd *ConnectionDetails) error {
 }
 
 func finalizerMySQL(cd *ConnectionDetails) {
+	cd.Host = defaults.String(cd.Host, hostMySQL)
 	cd.Port = defaults.String(cd.Port, portMySQL)
+
 	defs := map[string]string{
 		"parseTime":   "true",
 		"readTimeout": "1s",
@@ -220,15 +233,26 @@ func finalizerMySQL(cd *ConnectionDetails) {
 		"multiStatements": "true",
 	}
 
+	if cd.Options == nil { // prevent panic
+		cd.Options = make(map[string]string)
+	}
+
 	for k, v := range defs {
 		cd.Options[k] = defaults.String(cd.Options[k], v)
 	}
 
 	for k, v := range forced {
 		cd.Options[k] = defaults.String(cd.Options[k], v)
-		if !strings.Contains(cd.RawOptions, k+"="+v) {
+		if cd.URL != "" && !strings.Contains(cd.URL, k+"="+v) {
 			log(logging.Warn, "IMPORTANT! %s=%s option is required to work properly. Please add it to the database URL in the config!", k, v)
 		} // or fix user specified url?
+	}
+
+	if cd.Encoding != "" {
+		//! DEPRECATED, 2018-11-06
+		// when user still uses `encoding:` in database.yml
+		oncer.Deprecate(0, "Encoding", "use options.collation")
+		cd.Options["collation"] = cd.Encoding
 	}
 }
 

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -225,11 +225,11 @@ func finalizerMySQL(cd *ConnectionDetails) {
 	cd.Port = defaults.String(cd.Port, portMySQL)
 
 	defs := map[string]string{
-		"parseTime":   "true",
 		"readTimeout": "1s",
 		"collation":   "utf8mb4_general_ci",
 	}
 	forced := map[string]string{
+		"parseTime":       "true",
 		"multiStatements": "true",
 	}
 
@@ -242,9 +242,14 @@ func finalizerMySQL(cd *ConnectionDetails) {
 	}
 
 	for k, v := range forced {
+		// respect user specified options but print warning!
 		cd.Options[k] = defaults.String(cd.Options[k], v)
+		if cd.Options[k] != v { // when user-defined option exists
+			log(logging.Warn, "IMPORTANT! '%s: %s' option is required to work properly but your current setting is '%v: %v'.", k, v, k, cd.Options[k])
+			log(logging.Warn, "It is highly recommended to remove '%v: %v' option from your config!", k, cd.Options[k])
+		} // or override with `cd.Options[k] = v`?
 		if cd.URL != "" && !strings.Contains(cd.URL, k+"="+v) {
-			log(logging.Warn, "IMPORTANT! %s=%s option is required to work properly. Please add it to the database URL in the config!", k, v)
+			log(logging.Warn, "IMPORTANT! '%s=%s' option is required to work properly. Please add it to the database URL in the config!", k, v)
 		} // or fix user specified url?
 	}
 

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -1,8 +1,13 @@
 package pop
 
 import (
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/gobuffalo/fizz"
+	"github.com/gobuffalo/fizz/translators"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,9 +24,10 @@ func Test_MySQL_URL_As_Is(t *testing.T) {
 	m := &mysql{ConnectionDetails: cd}
 	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
 	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+	r.Equal("user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
 }
 
-func Test_MySQL_withURL(t *testing.T) {
+func Test_MySQL_URL_Override_withURL(t *testing.T) {
 	r := require.New(t)
 
 	cd := &ConnectionDetails{
@@ -38,64 +44,235 @@ func Test_MySQL_withURL(t *testing.T) {
 	m := &mysql{ConnectionDetails: cd}
 	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
 	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+	r.Equal("user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
 }
 
-func Test_MySQL_Default_Options(t *testing.T) {
+func Test_MySQL_URL_With_Values(t *testing.T) {
 	r := require.New(t)
-
-	cd := &ConnectionDetails{
-		Dialect:  "mysql",
-		Database: "base",
+	m := &mysql{ConnectionDetails: &ConnectionDetails{
+		Database: "dbase",
 		Host:     "host",
 		Port:     "port",
 		User:     "user",
 		Password: "pass",
-	}
-	err := cd.Finalize()
-	r.NoError(err)
+		Options:  map[string]string{"opt": "value"},
+	}}
+	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
+	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+	r.Equal("user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
+}
 
+func Test_MySQL_URL_Without_User(t *testing.T) {
+	r := require.New(t)
+	m := &mysql{ConnectionDetails: &ConnectionDetails{
+		Password: "pass",
+		Database: "dbase",
+	}}
+	// finalizerMySQL fills address part in real world.
+	// without user, password cannot live alone
+	r.Equal("(:)/dbase?", m.URL())
+}
+
+func Test_MySQL_URL_Without_Password(t *testing.T) {
+	r := require.New(t)
+	m := &mysql{ConnectionDetails: &ConnectionDetails{
+		User:     "user",
+		Database: "dbase",
+	}}
+	// finalizerMySQL fills address part in real world.
+	r.Equal("user@(:)/dbase?", m.URL())
+}
+
+func Test_MySQL_URL_urlParserMySQL_Standard(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		URL: "mysql://user:pass@(host:port)/database?collation=utf8&param2=value2",
+	}
+	err := urlParserMySQL(cd)
+	r.NoError(err)
+	r.Equal("user", cd.User)
+	r.Equal("pass", cd.Password)
+	r.Equal("host", cd.Host)
+	r.Equal("port", cd.Port)
+	r.Equal("database", cd.Database)
+	// only collation is stored as options by urlParserMySQL()
+	r.Equal("utf8", cd.Options["collation"])
+	r.Equal("", cd.Options["param2"])
+}
+
+func Test_MySQL_URL_urlParserMySQL_With_Protocol(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		URL: "user:pass@tcp(host:port)/dbase",
+	}
+	err := urlParserMySQL(cd)
+	r.NoError(err)
+	r.Equal("user", cd.User)
+	r.Equal("pass", cd.Password)
+	r.Equal("host", cd.Host)
+	r.Equal("port", cd.Port)
+	r.Equal("dbase", cd.Database)
+}
+
+func Test_MySQL_URL_urlParserMySQL_Socket(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		URL: "unix(/tmp/socket)/dbase",
+	}
+	err := urlParserMySQL(cd)
+	r.NoError(err)
+	r.Equal("/tmp/socket", cd.Host)
+	r.Equal("socket", cd.Port)
+
+	// additional test without URL
+	cd.URL = ""
 	m := &mysql{ConnectionDetails: cd}
-	r.True(strings.HasPrefix(m.URL(), "user:pass@(host:port)/base?"))
+	r.True(strings.HasPrefix(m.URL(), "unix(/tmp/socket)/dbase?"))
+	r.True(strings.HasPrefix(m.urlWithoutDb(), "unix(/tmp/socket)/?"))
+}
+
+func Test_MySQL_URL_urlParserMySQL_Unsupported(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		URL: "mysql://user:pass@host:port/dbase?opt=value",
+	}
+	err := urlParserMySQL(cd)
+	r.Error(err)
+}
+
+func Test_MySQL_Database_Open_Failure(t *testing.T) {
+	r := require.New(t)
+	m := &mysql{ConnectionDetails: &ConnectionDetails{}}
+	err := m.CreateDB()
+	r.Error(err)
+	err = m.DropDB()
+	r.Error(err)
+}
+
+func Test_MySQL_FizzTranslator(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{}
+	m := &mysql{ConnectionDetails: cd}
+	ft := m.FizzTranslator()
+	r.IsType(&translators.MySQL{}, ft)
+	r.Implements((*fizz.Translator)(nil), ft)
+}
+
+func Test_MySQL_Finalizer_Default_CD(t *testing.T) {
+	r := require.New(t)
+	m := &mysql{ConnectionDetails: &ConnectionDetails{}}
+	finalizerMySQL(m.ConnectionDetails)
+	r.Equal(hostMySQL, m.ConnectionDetails.Host)
+	r.Equal(portMySQL, m.ConnectionDetails.Port)
+}
+
+func Test_MySQL_Finalizer_Default_Options(t *testing.T) {
+	r := require.New(t)
+	m := &mysql{ConnectionDetails: &ConnectionDetails{}}
+	finalizerMySQL(m.ConnectionDetails)
 	r.Contains(m.URL(), "multiStatements=true")
 	r.Contains(m.URL(), "parseTime=true")
 	r.Contains(m.URL(), "readTimeout=1s")
 	r.Contains(m.URL(), "collation=utf8mb4_general_ci")
-	r.True(strings.HasPrefix(m.urlWithoutDb(), "user:pass@(host:port)/?"))
-	r.Contains(m.urlWithoutDb(), "multiStatements=true")
-	r.Contains(m.urlWithoutDb(), "parseTime=true")
-	r.Contains(m.urlWithoutDb(), "readTimeout=1s")
-	r.Contains(m.urlWithoutDb(), "collation=utf8mb4_general_ci")
 }
 
-func Test_MySQL_User_Defined_Options(t *testing.T) {
+func Test_MySQL_Finalizer_Preserve_User_Defined_Options(t *testing.T) {
 	r := require.New(t)
-
-	cd := &ConnectionDetails{
-		Dialect:  "mysql",
-		Database: "base",
-		Host:     "host",
-		Port:     "port",
-		User:     "user",
-		Password: "pass",
+	m := &mysql{ConnectionDetails: &ConnectionDetails{
 		Options: map[string]string{
 			"multiStatements": "false",
 			"parseTime":       "false",
 			"readTimeout":     "1h",
 			"collation":       "utf8",
 		},
-	}
-	err := cd.Finalize()
-	r.NoError(err)
-
-	m := &mysql{ConnectionDetails: cd}
-	r.True(strings.HasPrefix(m.URL(), "user:pass@(host:port)/base?"))
+	}}
+	finalizerMySQL(m.ConnectionDetails)
 	r.Contains(m.URL(), "multiStatements=false")
 	r.Contains(m.URL(), "parseTime=false")
 	r.Contains(m.URL(), "readTimeout=1h")
 	r.Contains(m.URL(), "collation=utf8")
-	r.True(strings.HasPrefix(m.urlWithoutDb(), "user:pass@(host:port)/?"))
-	r.Contains(m.urlWithoutDb(), "multiStatements=false")
-	r.Contains(m.urlWithoutDb(), "parseTime=false")
-	r.Contains(m.urlWithoutDb(), "readTimeout=1h")
-	r.Contains(m.urlWithoutDb(), "collation=utf8")
+}
+
+//*** extra test for DLL operations
+func getConnectionForExtraTest(t *testing.T, dialect string) *Connection {
+	r := require.New(t)
+	err := LoadConfigFile()
+	r.NoError(err)
+
+	testFor := os.Getenv("SODA_DIALECT")
+	if dialect != testFor {
+		return nil // not my turn
+	}
+	if "on" != os.Getenv("POP_EXTRA_TEST") {
+		t.Logf("Skip extra DDL tests for %v.", dialect)
+		t.Log("POP_EXTRA_TEST=on if you want to run extra tests.")
+		return nil
+	}
+	t.Logf("Current SODA_DIALECT is %v. Test more...\n", testFor)
+
+	connection := Connections[testFor]
+	r.NotNil(connection, "oops! doing extra tests but could not found connection!")
+	t.Logf("Use connection: %v\n", connection)
+
+	return connection
+}
+
+func Test_MySQL_DDL_Operations(t *testing.T) {
+	r := require.New(t)
+	c := getConnectionForExtraTest(t, "mysql")
+	if c == nil {
+		return
+	}
+
+	d := c.Dialect
+	cd := d.Details()
+	cd.Database = "pop_test_mysql_extra"
+
+	d.DropDB()
+	err := d.CreateDB()
+	r.NoError(err)
+	err = d.CreateDB()
+	r.Error(err)
+	err = d.DropDB()
+	r.NoError(err)
+}
+
+func Test_MySQL_DDL_Schema(t *testing.T) {
+	r := require.New(t)
+	c := getConnectionForExtraTest(t, "mysql")
+	if c == nil {
+		return
+	}
+
+	d := c.Dialect
+
+	f, err := ioutil.TempFile(os.TempDir(), "pop_test_mysql_dump")
+	r.NoError(err)
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
+	err = d.DumpSchema(f)
+	r.NoError(err)
+	f.Seek(0, 0)
+	err = d.LoadSchema(f)
+	r.NoError(err)
+
+	d.Details().Database = "notExistingDatabase"
+	f.Seek(0, 0)
+	err = d.LoadSchema(f)
+	r.Error(err)
+	err = d.DumpSchema(f)
+	r.Error(err)
+}
+
+//** DEPRECATED: preserve test cases below while deprecated codes alive
+func Test_MySQL_Deprecated_CD_Encoding(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{Encoding: "myEncoding"}
+	finalizerMySQL(cd)
+	r.NotNil(cd.Options)
+	r.Equal("myEncoding", cd.Encoding)
+	r.Equal("myEncoding", cd.Options["collation"])
 }

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -193,24 +193,8 @@ func Test_MySQL_Finalizer_Preserve_User_Defined_Options(t *testing.T) {
 	r.Contains(m.URL(), "collation=utf8")
 }
 
-//*** extra test for DLL operations
-func isExtraTestOnFor(t *testing.T, dialect string) bool {
-	if PDB.Dialect.Details().Dialect != dialect {
-		return false
-	}
-	if "on" != os.Getenv("POP_EXTRA_TEST") {
-		t.Log("Skip extra DDL tests. Set POP_EXTRA_TEST=on if you want to run extra tests.")
-		return false
-	}
-	t.Logf("extra test for %v permmitted", dialect)
-	return true
-}
-
-func Test_MySQL_DDL_Operations(t *testing.T) {
-	r := require.New(t)
-	if !isExtraTestOnFor(t, "mysql") {
-		return
-	}
+func (s *MySQLSuite) Test_MySQL_DDL_Operations() {
+	r := s.Require()
 
 	origDatabase := PDB.Dialect.Details().Database
 	PDB.Dialect.Details().Database = "pop_test_mysql_extra"
@@ -229,11 +213,8 @@ func Test_MySQL_DDL_Operations(t *testing.T) {
 	r.Error(err)
 }
 
-func Test_MySQL_DDL_Schema(t *testing.T) {
-	r := require.New(t)
-	if !isExtraTestOnFor(t, "mysql") {
-		return
-	}
+func (s *MySQLSuite) Test_MySQL_DDL_Schema() {
+	r := s.Require()
 
 	f, err := ioutil.TempFile(os.TempDir(), "pop_test_mysql_dump")
 	r.NoError(err)


### PR DESCRIPTION
With this PR and previously merged PR, all hardcoded options for MySQL dialect are removed and it can be configured with `options` in `database.yml`. For example,

```yaml
development:
  dialect: mysql
  options:
    collation: utf8mb4_general_ci
    readTimeout: 1s
    parseTime: true
    multiStatements: true
```

Previously,

* `collation`: was configured with `encoding` key (high level key but only used by MySQL)
* `readTimeout`: was hardcoded for generated URL and changed from time to time.
* `parseTime` and `multiStatements`: was hardcoded for generated URL.

For `encoding` configuration, deprecated message was added to notice users.

There are some minor bugfixes related to these changes and added some test cases to cover most of the codes.

(related to #281)