### PR TITLE
Fix version field size in migrations table

### DIFF
--- a/schema_migrations.go
+++ b/schema_migrations.go
@@ -12,7 +12,13 @@ func newSchemaMigrations(name string) fizz.Table {
 	return fizz.Table{
 		Name: name,
 		Columns: []fizz.Column{
-			{Name: "version", ColType: "string"},
+			{
+				Name:    "version",
+				ColType: "string",
+				Options: map[string]interface{}{
+					"size": 14, // len(YYYYMMDDhhmmss)
+				},
+			},
 		},
 		Indexes: []fizz.Index{
 			{Name: fmt.Sprintf("%s_version_idx", name), Columns: []string{"version"}, Unique: true},

--- a/schema_migrations_appengine.go
+++ b/schema_migrations_appengine.go
@@ -8,7 +8,13 @@ func newSchemaMigrations(name string) fizz.Table {
 	return fizz.Table{
 		Name: name,
 		Columns: []fizz.Column{
-			{Name: "version", ColType: "string"},
+			{
+				Name:    "version",
+				ColType: "string",
+				Options: map[string]interface{}{
+					"size": 14, // len(YYYYMMDDhhmmss)
+				},
+			},
 		},
 		Indexes: []fizz.Index{},
 	}


### PR DESCRIPTION
This will prevent big indexes for nothing.