### PR TITLE
Fixes beforeSave pointer panics

### DIFF
--- a/associations/belongs_to_association.go
+++ b/associations/belongs_to_association.go
@@ -99,7 +99,7 @@ func (b *belongsToAssociation) BeforeInterface() interface{} {
 	}
 
 	m := b.ownerModel
-	if m.Kind() == reflect.Ptr {
+	if m.Kind() == reflect.Ptr && !m.IsNil() {
 		m = b.ownerModel.Elem()
 	}
 
@@ -111,12 +111,14 @@ func (b *belongsToAssociation) BeforeInterface() interface{} {
 }
 
 func (b *belongsToAssociation) BeforeSetup() error {
-	ownerID := reflect.Indirect(reflect.ValueOf(b.ownerModel.Interface())).FieldByName("ID").Interface()
+	ownerID := reflect.Indirect(reflect.ValueOf(b.ownerModel.Interface())).FieldByName("ID")
 	if b.ownerID.CanSet() {
 		if n := nulls.New(b.ownerID.Interface()); n != nil {
-			b.ownerID.Set(reflect.ValueOf(n.Parse(ownerID)))
+			b.ownerID.Set(reflect.ValueOf(n.Parse(ownerID.Interface())))
+		} else if b.ownerID.Kind() == reflect.Ptr {
+			b.ownerID.Set(ownerID.Addr())
 		} else {
-			b.ownerID.Set(reflect.ValueOf(ownerID))
+			b.ownerID.Set(ownerID)
 		}
 		return nil
 	}

--- a/executors_test.go
+++ b/executors_test.go
@@ -976,10 +976,10 @@ func Test_Create_Belongs_To_Pointers(t *testing.T) {
 		err = tx.Create(&created)
 		r.NoError(err)
 
-		new := HeadPtr{}
-		err = tx.Find(&new, created.ID)
+		found := HeadPtr{}
+		err = tx.Find(&found, created.ID)
 		r.NoError(err)
-		r.Equal(body.ID, *new.BodyID)
+		r.Equal(body.ID, *found.BodyID)
 	})
 }
 

--- a/executors_test.go
+++ b/executors_test.go
@@ -947,6 +947,39 @@ func Test_Eager_Create_Belongs_To_Pointers(t *testing.T) {
 
 		ctx, _ = tx.Count(&Head{})
 		r.Equal(1, ctx)
+
+		err = tx.Eager().Create(&Head{
+			BodyID: body.ID,
+			Body:   nil,
+		})
+		r.NoError(err)
+	})
+}
+
+func Test_Create_Belongs_To_Pointers(t *testing.T) {
+	transaction(func(tx *Connection) {
+		r := require.New(t)
+		// Create a body without a head:
+		body := Body{
+			Head: nil,
+		}
+
+		err := tx.Create(&body)
+		r.NoError(err)
+		r.NotZero(body.ID)
+		r.Nil(body.Head)
+
+		// Create a head with the associated model set but not the ID
+		created := HeadPtr{
+			Body: &body,
+		}
+		err = tx.Create(&created)
+		r.NoError(err)
+
+		new := HeadPtr{}
+		err = tx.Find(&new, created.ID)
+		r.NoError(err)
+		r.Equal(body.ID, *new.BodyID)
 	})
 }
 

--- a/migrations/20181130023854_head_ptr.down.fizz
+++ b/migrations/20181130023854_head_ptr.down.fizz
@@ -1,0 +1,1 @@
+drop_table("head_ptrs")

--- a/migrations/20181130023854_head_ptr.up.fizz
+++ b/migrations/20181130023854_head_ptr.up.fizz
@@ -1,0 +1,6 @@
+create_table("head_ptrs") {
+ t.Column("id", "integer", {"primary": true})
+ t.Column("body_id", "integer", {"null": true})
+ t.ForeignKey("body_id", {"bodies": ["id"]}, {})
+ t.DisableTimestamps()
+}

--- a/pop_test.go
+++ b/pop_test.go
@@ -354,3 +354,9 @@ type Head struct {
 	BodyID int   `json:"-" db:"body_id"`
 	Body   *Body `json:"body,omitempty" belongs_to:"body"`
 }
+
+type HeadPtr struct {
+	ID     int   `json:"id,omitempty" db:"id"`
+	BodyID *int  `json:"-" db:"body_id"`
+	Body   *Body `json:"body,omitempty" belongs_to:"body"`
+}


### PR DESCRIPTION
Fixes a couple panics when working with pointers and beforeSave associations:
- The first was calling `Elem()` on a nil pointer, which returns a zero value that `Interface()` later panics on
- The second panic occurs when `BeforeSetup` attempts to set a pointer-type associated ID field