### PR TITLE
Improving connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -90,14 +90,18 @@ func (c *Connection) Open() error {
 	if c.Store != nil {
 		return nil
 	}
+	if c.Dialect == nil {
+		return errors.New("invalid connection instance")
+	}
 	details := c.Dialect.Details()
 	db, err := sqlx.Open(details.Dialect, c.Dialect.URL())
+	if err != nil {
+		return errors.Wrap(err, "couldn't connect to database")
+	}
 	db.SetMaxOpenConns(details.Pool)
 	db.SetMaxIdleConns(details.IdlePool)
-	if err == nil {
-		c.Store = &dB{db}
-	}
-	return errors.Wrap(err, "couldn't connect to database")
+	c.Store = &dB{db}
+	return nil
 }
 
 // Close destroys an active datasource connection

--- a/connection.go
+++ b/connection.go
@@ -96,12 +96,17 @@ func (c *Connection) Open() error {
 	details := c.Dialect.Details()
 	db, err := sqlx.Open(details.Dialect, c.Dialect.URL())
 	if err != nil {
-		return errors.Wrap(err, "couldn't connect to database")
+		return errors.Wrap(err, "could not open database connection")
 	}
 	db.SetMaxOpenConns(details.Pool)
 	db.SetMaxIdleConns(details.IdlePool)
 	c.Store = &dB{db}
-	return nil
+
+	err = c.Dialect.afterOpen(c)
+	if err != nil {
+		c.Store = nil
+	}
+	return errors.Wrap(err, "could not open database connection")
 }
 
 // Close destroys an active datasource connection

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,1 +1,52 @@
 package pop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Connection_SimpleFlow(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		URL: "sqlite:///foo.db",
+	}
+	c, err := NewConnection(cd)
+	r.NoError(err)
+
+	err = c.Open()
+	r.NoError(err)
+	err = c.Open() // open again
+	r.NoError(err)
+	err = c.Close()
+	r.NoError(err)
+}
+
+func Test_Connection_Open_NoDialect(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		URL: "sqlite:///foo.db",
+	}
+	c, err := NewConnection(cd)
+	r.NoError(err)
+
+	c.Dialect = nil
+	err = c.Open()
+	r.Error(err)
+}
+
+func Test_Connection_Open_BadDialect(t *testing.T) {
+	r := require.New(t)
+
+	cd := &ConnectionDetails{
+		URL: "sqlite:///foo.db",
+	}
+	c, err := NewConnection(cd)
+	r.NoError(err)
+
+	cd.Dialect = "unknown"
+	err = c.Open()
+	r.Error(err)
+}

--- a/dialect.go
+++ b/dialect.go
@@ -40,6 +40,7 @@ type dialect interface {
 	FizzTranslator() fizz.Translator
 	Lock(func() error) error
 	TruncateAll(*Connection) error
+	afterOpen(*Connection) error
 }
 
 func genericCreate(s store, model *Model, cols columns.Columns) error {

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -185,6 +185,10 @@ func (m *mysql) TruncateAll(tx *Connection) error {
 	return tx.RawQuery(qb.String()).Exec()
 }
 
+func (m *mysql) afterOpen(c *Connection) error {
+	return nil
+}
+
 func newMySQL(deets *ConnectionDetails) (dialect, error) {
 	cd := &mysql{
 		ConnectionDetails: deets,

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -199,6 +199,10 @@ func (p *postgresql) TruncateAll(tx *Connection) error {
 	return tx.RawQuery(fmt.Sprintf(pgTruncate, tx.MigrationTableName())).Exec()
 }
 
+func (p *postgresql) afterOpen(c *Connection) error {
+	return nil
+}
+
 func newPostgreSQL(deets *ConnectionDetails) (dialect, error) {
 	cd := &postgresql{
 		ConnectionDetails: deets,

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -211,6 +211,10 @@ func (m *sqlite) TruncateAll(tx *Connection) error {
 	return tx.RawQuery(strings.Join(stmts, "; ")).Exec()
 }
 
+func (m *sqlite) afterOpen(c *Connection) error {
+	return nil
+}
+
 func newSQLite(deets *ConnectionDetails) (dialect, error) {
 	deets.URL = fmt.Sprintf("sqlite3://%s", deets.Database)
 	cd := &sqlite{


### PR DESCRIPTION
Added callback function `afterOpen()` to interface `dialect` and call it from `Connection.Open()` to handle dialect specific initial setup. (as first part of proposal #295)

With this, I hope we can give dialect a change to prepare its own settings include getting server information which I already added to dialect for CockroachDB. I think it can help us to handle version different of the same database engine and service variations. (with the information from the connected server.)

Before I adding this, I made a small change to `connection.go` to prevent panic on the badly configured connection.

Please check this PR.