### PR TITLE
Handle transaction panic

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,3 +72,8 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+brew:
+  github:
+    owner: gobuffalo
+    name: homebrew-tap

--- a/connection.go
+++ b/connection.go
@@ -124,6 +124,12 @@ func (c *Connection) Transaction(fn func(tx *Connection) error) error {
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err := recover(); err != nil {
+				cn.TX.Rollback()
+				err = errors.Errorf("panic err %v", err)
+			}
+		}()
 		err = fn(cn)
 		if err != nil {
 			dberr = cn.TX.Rollback()

--- a/soda/cmd/version.go
+++ b/soda/cmd/version.go
@@ -1,4 +1,4 @@
 package cmd
 
 // Version defines the current Pop version.
-const Version = "v4.9.4-rc.2"
+const Version = "v4.9.4"


### PR DESCRIPTION
Handle panic that comes from the fn `func(tx *Connection)` parameter.

Whenever a panic occurs in a `Connection.Transaction` the `TX.Rollback` or `TX.Commit` is not called after the panic has been recovered. Any call to the `Connection.Transaction` would block forever.