### PR TITLE
fix(nulls): do not throw an error when parsing a float string into an int field

### DIFF
--- a/nulls/int.go
+++ b/nulls/int.go
@@ -55,7 +55,7 @@ func (ns Int) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON will unmarshal a JSON value into
-// the propert representation of that value.
+// the proper representation of that value.
 func (ns *Int) UnmarshalJSON(text []byte) error {
 	txt := string(text)
 	ns.Valid = true
@@ -63,7 +63,7 @@ func (ns *Int) UnmarshalJSON(text []byte) error {
 		ns.Valid = false
 		return nil
 	}
-	i, err := strconv.ParseInt(txt, 10, strconv.IntSize)
+	i, err := strconv.ParseFloat(txt, 32)
 	if err != nil {
 		ns.Valid = false
 		return err

--- a/nulls/int32.go
+++ b/nulls/int32.go
@@ -63,7 +63,7 @@ func (ns *Int32) UnmarshalJSON(text []byte) error {
 		ns.Valid = false
 		return nil
 	}
-	i, err := strconv.ParseFloat(txt,32)
+	i, err := strconv.ParseFloat(txt, 32)
 	if err != nil {
 		ns.Valid = false
 		return err

--- a/nulls/int32.go
+++ b/nulls/int32.go
@@ -55,7 +55,7 @@ func (ns Int32) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON will unmarshal a JSON value into
-// the propert representation of that value.
+// the proper representation of that value.
 func (ns *Int32) UnmarshalJSON(text []byte) error {
 	txt := string(text)
 	ns.Valid = true
@@ -63,7 +63,7 @@ func (ns *Int32) UnmarshalJSON(text []byte) error {
 		ns.Valid = false
 		return nil
 	}
-	i, err := strconv.ParseInt(txt, 10, 32)
+	i, err := strconv.ParseFloat(txt,32)
 	if err != nil {
 		ns.Valid = false
 		return err

--- a/nulls/int32_test.go
+++ b/nulls/int32_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_IntUnmarshalJSON(t *testing.T) {
+func Test_Int32UnmarshalJSON(t *testing.T) {
 	r := require.New(t)
 	cases := []struct {
 		Input []byte
-		Value int
+		Value int32
 		Valid bool
 	}{
 		{
@@ -37,14 +37,14 @@ func Test_IntUnmarshalJSON(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		i := nulls.Int{}
+		i := nulls.Int32{}
 		r.NoError(i.UnmarshalJSON(c.Input))
-		r.Equal(c.Value, i.Int)
+		r.Equal(c.Value, i.Int32)
 		r.Equal(c.Valid, i.Valid)
 	}
 }
 
-func Test_IntUnmarshalJSON_Errors(t *testing.T) {
+func Test_Int32UnmarshalJSON_Errors(t *testing.T) {
 	r := require.New(t)
 
 	cases := []struct {
@@ -59,9 +59,9 @@ func Test_IntUnmarshalJSON_Errors(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		i := nulls.Int{}
+		i := nulls.Int32{}
 		r.Error(i.UnmarshalJSON(c.Input))
-		r.Equal(0, i.Int)
+		r.Equal(int32(0), i.Int32)
 		r.False(i.Valid)
 	}
 }

--- a/nulls/int64.go
+++ b/nulls/int64.go
@@ -52,7 +52,7 @@ func (ns Int64) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON will unmarshal a JSON value into
-// the propert representation of that value.
+// the proper representation of that value.
 func (ns *Int64) UnmarshalJSON(text []byte) error {
 	t := string(text)
 	ns.Valid = true
@@ -60,12 +60,12 @@ func (ns *Int64) UnmarshalJSON(text []byte) error {
 		ns.Valid = false
 		return nil
 	}
-	i, err := strconv.ParseInt(t, 10, 64)
+	i, err := strconv.ParseFloat(t,  64)
 	if err != nil {
 		ns.Valid = false
 		return err
 	}
-	ns.Int64 = i
+	ns.Int64 = int64(i)
 	return nil
 }
 

--- a/nulls/int64.go
+++ b/nulls/int64.go
@@ -60,7 +60,7 @@ func (ns *Int64) UnmarshalJSON(text []byte) error {
 		ns.Valid = false
 		return nil
 	}
-	i, err := strconv.ParseFloat(t,  64)
+	i, err := strconv.ParseFloat(t, 64)
 	if err != nil {
 		ns.Valid = false
 		return err

--- a/nulls/int64_test.go
+++ b/nulls/int64_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_IntUnmarshalJSON(t *testing.T) {
+func Test_Int64UnmarshalJSON(t *testing.T) {
 	r := require.New(t)
 	cases := []struct {
 		Input []byte
-		Value int
+		Value int64
 		Valid bool
 	}{
 		{
@@ -37,14 +37,14 @@ func Test_IntUnmarshalJSON(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		i := nulls.Int{}
+		i := nulls.Int64{}
 		r.NoError(i.UnmarshalJSON(c.Input))
-		r.Equal(c.Value, i.Int)
+		r.Equal(c.Value, i.Int64)
 		r.Equal(c.Valid, i.Valid)
 	}
 }
 
-func Test_IntUnmarshalJSON_Errors(t *testing.T) {
+func Test_Int64UnmarshalJSON_Errors(t *testing.T) {
 	r := require.New(t)
 
 	cases := []struct {
@@ -59,9 +59,9 @@ func Test_IntUnmarshalJSON_Errors(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		i := nulls.Int{}
+		i := nulls.Int64{}
 		r.Error(i.UnmarshalJSON(c.Input))
-		r.Equal(0, i.Int)
+		r.Equal(int64(0), i.Int64)
 		r.False(i.Valid)
 	}
 }


### PR DESCRIPTION
Currently, if an integer field is specified as a floating point string, an error will be thrown when unmarshalling. 

ex: If i have a struct defined as follows:
```
type MyObject {
  intField nulls.Int `json:"int_field"`
}
```

and I try to unmarshal the following json :

`{"int_field": "1.0"}`,

 it will throw an error rather than parsing it as an int.

This is very problematic when using buffalo's `c.Bind` in a request handler.

For example, I would like to do the following:

```
if err := c.Bind(myStruct); err != nil {
	return errors.WithStack(err)
}
// DO VALIDATION
```

If the binding itself throws an error, I never get the chance to call my validation functions and return a meaningful error (ex: `field X invalid because reason Y`). The parsing should be more lenient and `Bind` should not throw an error if an integer was specified as a float.

This PR should address the issue described