### PR TITLE
Add Timestamps() macro when generating fizz migrations

### DIFF
--- a/migrations/20181104135255_users.up.fizz
+++ b/migrations/20181104135255_users.up.fizz
@@ -7,4 +7,5 @@ create_table("users") {
   t.Column("bio", "text", {"null": true})
   t.Column("price", "numeric", {"null": true, "default": "1.00"})
   t.Column("email", "string", {"default": "foo@example.com", "size": 50})
+  t.Timestamps()
 }

--- a/migrations/20181104135526_good_friends.up.fizz
+++ b/migrations/20181104135526_good_friends.up.fizz
@@ -2,4 +2,5 @@ create_table("good_friends") {
   t.Column("id", "int", {primary: true})
   t.Column("first_name", "string", {})
   t.Column("last_name", "string", {})
+  t.Timestamps()
 }

--- a/migrations/20181104135627_validatable_cars.up.fizz
+++ b/migrations/20181104135627_validatable_cars.up.fizz
@@ -1,4 +1,5 @@
 create_table("validatable_cars") {
   t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
+  t.Timestamps()
 }

--- a/migrations/20181104135710_not_validatable_cars.up.fizz
+++ b/migrations/20181104135710_not_validatable_cars.up.fizz
@@ -1,4 +1,5 @@
 create_table("not_validatable_cars") {
   t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
+  t.Timestamps()
 }

--- a/migrations/20181104135800_callbacks_users.up.fizz
+++ b/migrations/20181104135800_callbacks_users.up.fizz
@@ -9,4 +9,5 @@ create_table("callbacks_users") {
   t.Column("after_u", "string", {})
   t.Column("after_d", "string", {})
   t.Column("after_f", "string", {})
+  t.Timestamps()
 }

--- a/migrations/20181104135829_books.up.fizz
+++ b/migrations/20181104135829_books.up.fizz
@@ -3,4 +3,5 @@ create_table("books") {
   t.Column("title", "string", {})
   t.Column("user_id", "int", {"null": true})
   t.Column("isbn", "string", {"size": 50})
+  t.Timestamps()
 }

--- a/migrations/20181104135856_taxis.up.fizz
+++ b/migrations/20181104135856_taxis.up.fizz
@@ -2,4 +2,5 @@ create_table("taxis") {
   t.Column("id", "int", {primary: true})
   t.Column("model", "string", {})
   t.Column("user_id", "int", {"null": true})
+  t.Timestamps()
 }

--- a/migrations/20181104140055_songs.up.fizz
+++ b/migrations/20181104140055_songs.up.fizz
@@ -3,4 +3,5 @@ create_table("songs") {
   t.Column("u_id", "int", {"null":true})
   t.Column("title", "string", {})
   t.Column("composed_by_id", "int", {"null":true})
+  t.Timestamps()
 }

--- a/migrations/20181104140142_composers.up.fizz
+++ b/migrations/20181104140142_composers.up.fizz
@@ -1,4 +1,5 @@
 create_table("composers") {
   t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
+  t.Timestamps()
 }

--- a/migrations/20181104140221_writers.up.fizz
+++ b/migrations/20181104140221_writers.up.fizz
@@ -2,4 +2,5 @@ create_table("writers") {
   t.Column("id", "int", {primary: true})
   t.Column("name", "string", {})
   t.Column("book_id", "int", {})
+  t.Timestamps()
 }

--- a/migrations/20181104140340_addresses.up.fizz
+++ b/migrations/20181104140340_addresses.up.fizz
@@ -2,4 +2,5 @@ create_table("addresses") {
   t.Column("id", "int", {primary: true})
   t.Column("street", "string", {})
   t.Column("house_number", "int", {})
+  t.Timestamps()
 }

--- a/migrations/20181104140431_users_addresses.up.fizz
+++ b/migrations/20181104140431_users_addresses.up.fizz
@@ -2,4 +2,5 @@ create_table("users_addresses") {
   t.Column("id", "int", {primary: true})
   t.Column("user_id", "int", {})
   t.Column("address_id", "int", {})
+  t.Timestamps()
 }

--- a/migrations/20181104140522_courses.up.fizz
+++ b/migrations/20181104140522_courses.up.fizz
@@ -1,3 +1,4 @@
 create_table("courses") {
   t.Column("id", "uuid", {"primary": true})
+  t.Timestamps()
 }

--- a/migrations/20181104140606_course_codes.up.fizz
+++ b/migrations/20181104140606_course_codes.up.fizz
@@ -1,4 +1,5 @@
 create_table("course_codes") {
   t.Column("id", "uuid", {"primary": true})
   t.Column("course_id", "uuid", {})
+  t.Timestamps()
 }

--- a/migrations/20181104140743_cakes.up.fizz
+++ b/migrations/20181104140743_cakes.up.fizz
@@ -4,5 +4,6 @@
     t.Column("int_slice", "int[]", {"null": true})
     t.Column("float_slice", "numeric[]", {"null": true})
     t.Column("string_slice", "varchar[]", {"null": true})
+    t.Timestamps()
 }
 {{ end -}}

--- a/migrations/20190219210052_students.up.fizz
+++ b/migrations/20190219210052_students.up.fizz
@@ -1,3 +1,4 @@
 create_table("students") {
  t.Column("id", "uuid", {"primary": true})
+ t.Timestamps()
 }

--- a/migrations/20190219210059_parents.up.fizz
+++ b/migrations/20190219210059_parents.up.fizz
@@ -1,3 +1,4 @@
 create_table("parents") {
  t.Column("id", "uuid", {"primary": true})
+ t.Timestamps()
 }

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -203,6 +203,7 @@ func (m model) Fizz() string {
 			s = append(s, "\t"+col.String())
 		}
 	}
+	s = append(s, "\tt.Timestamps()")
 	s = append(s, "}")
 	return strings.Join(s, "\n")
 }

--- a/soda/cmd/generate/model_test.go
+++ b/soda/cmd/generate/model_test.go
@@ -196,6 +196,7 @@ func Test_model_Fizz(t *testing.T) {
 	t.Column("id", "integer", {primary: true})
 	t.Column("brand", "string", {})
 	t.Column("owner", "string", {null: true})
+	t.Timestamps()
 }`
 	r.Equal(expected, m.Fizz())
 }


### PR DESCRIPTION
Related to #155. This still needs a proper change to the fix command.