### PR TITLE
Fix IdlePool option

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -99,7 +99,9 @@ func (c *Connection) Open() error {
 		return errors.Wrap(err, "could not open database connection")
 	}
 	db.SetMaxOpenConns(details.Pool)
-	db.SetMaxIdleConns(details.IdlePool)
+	if details.IdlePool != 0 {
+		db.SetMaxIdleConns(details.IdlePool)
+	}
 	c.Store = &dB{db}
 
 	if d, ok := c.Dialect.(afterOpenable); ok {

--- a/connection_details.go
+++ b/connection_details.go
@@ -37,7 +37,7 @@ type ConnectionDetails struct {
 	URL string
 	// Defaults to 0 "unlimited". See https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns
 	Pool int
-	// Defaults to 0 "unlimited". See https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
+	// Defaults to 2. See https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 	IdlePool int
 	Options  map[string]string
 	// Query string encoded options from URL. Example: "sslmode=disable"


### PR DESCRIPTION
The zero value was not the same as in the stdlib and could cause
perfs issues. This will now not call SetMaxIdleConns when IdlePool
is set to the zero value.

Fixes #376