### PR TITLE
Optimize Count

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -15,14 +15,14 @@ var Connections = map[string]*Connection{}
 
 // Connection represents all necessary details to talk with a datastore
 type Connection struct {
-	ID          string
-	Store       store
-	Dialect     dialect
-	Elapsed     int64
-	TX          *Tx
-	eager       bool
-	eagerFields []string
-	OptimizeCount           bool
+	ID            string
+	Store         store
+	Dialect       dialect
+	Elapsed       int64
+	TX            *Tx
+	eager         bool
+	eagerFields   []string
+	OptimizeCount bool
 }
 
 func (c *Connection) String() string {

--- a/connection.go
+++ b/connection.go
@@ -22,6 +22,7 @@ type Connection struct {
 	TX          *Tx
 	eager       bool
 	eagerFields []string
+	OptimizeCount           bool
 }
 
 func (c *Connection) String() string {

--- a/finders.go
+++ b/finders.go
@@ -332,7 +332,7 @@ func (q Query) CountByField(model interface{}, field string) (int, error) {
 		tmpQuery.Paginator = nil
 		tmpQuery.orderClauses = clauses{}
 		tmpQuery.limitResults = 0
-		query, args := tmpQuery.ToSQL(&Model{Value: model, ignoreTableName: true}, "COUNT(*)")
+		query, args := tmpQuery.ToSQL(&Model{Value: model, ignoreTableName: true}, "COUNT(*) as row_count")
 		//when query contains custom selected fields / executed using RawQuery,
 		//	sql may already contains limit and offset
 

--- a/finders.go
+++ b/finders.go
@@ -332,7 +332,7 @@ func (q Query) CountByField(model interface{}, field string) (int, error) {
 		tmpQuery.Paginator = nil
 		tmpQuery.orderClauses = clauses{}
 		tmpQuery.limitResults = 0
-		query, args := tmpQuery.ToSQL(&Model{Value: model})
+		query, args := tmpQuery.ToSQL(&Model{Value: model, ignoreTableName: true}, "COUNT(*)")
 		//when query contains custom selected fields / executed using RawQuery,
 		//	sql may already contains limit and offset
 
@@ -344,9 +344,9 @@ func (q Query) CountByField(model interface{}, field string) (int, error) {
 			query = query[0 : len(query)-len(foundLimit)]
 		}
 
-		countQuery := fmt.Sprintf("SELECT COUNT(%s) AS row_count FROM (%s) a", field, query)
-		log(logging.SQL, countQuery, args...)
-		return q.Connection.Store.Get(res, countQuery, args...)
+		// countQuery := fmt.Sprintf("SELECT COUNT(%s) AS row_count FROM (%s) a", field, query)
+		log(logging.SQL, query, args...)
+		return q.Connection.Store.Get(res, query, args...)
 	})
 	return res.Count, err
 }

--- a/finders.go
+++ b/finders.go
@@ -341,8 +341,11 @@ func (q Query) CountByField(model interface{}, field string) (int, error) {
 			isRaw = true
 		}
 
+		// Count can't be optimized if the query contains raw SQL due to ToSQL internals
 		if tmpQuery.OptimizeCount && !isRaw {
-			tmpQuery.addColumns = []string{}
+			tmpQuery.addColumns = []string{} // Optimizing Count means giving up selecting any distinct columns.
+			// This can be changed in the future but will also have to address the issue of
+			// table aliasing in column names -- AKA reevaluating how Model.ignoreTableName works.
 			query, args = tmpQuery.ToSQL(&Model{Value: model, ignoreTableName: true},
 				fmt.Sprintf("COUNT(%s) as row_count", field))
 		} else {

--- a/finders.go
+++ b/finders.go
@@ -335,13 +335,18 @@ func (q Query) CountByField(model interface{}, field string) (int, error) {
 
 		var query, countQuery string
 		var args []interface{}
+		var isRaw bool
 
-		if tmpQuery.OptimizeCount && tmpQuery.RawSQL == nil {
+		if tmpQuery.RawSQL != nil && tmpQuery.RawSQL.Fragment != "" {
+			isRaw = true
+		}
+
+		if tmpQuery.OptimizeCount && !isRaw {
 			tmpQuery.addColumns = []string{}
 			query, args = tmpQuery.ToSQL(&Model{Value: model, ignoreTableName: true},
 				fmt.Sprintf("COUNT(%s) as row_count", field))
 		} else {
-			if tmpQuery.OptimizeCount && tmpQuery.RawSQL != nil {
+			if tmpQuery.OptimizeCount && isRaw {
 				log(logging.Warn, "Query contains raw SQL; COUNT cannot be optimized")
 			}
 

--- a/model.go
+++ b/model.go
@@ -23,8 +23,9 @@ type modelIterable func(*Model) error
 // that is passed in to many functions.
 type Model struct {
 	Value
-	tableName string
-	As        string
+	tableName       string
+	As              string
+	ignoreTableName bool
 }
 
 // ID returns the ID of the Model. All models must have an `ID` field this is

--- a/query.go
+++ b/query.go
@@ -184,6 +184,7 @@ func Q(c *Connection) *Query {
 		Connection:  c,
 		eager:       c.eager,
 		eagerFields: c.eagerFields,
+		OptimizeCount: c.OptimizeCount,
 	}
 }
 

--- a/query.go
+++ b/query.go
@@ -24,6 +24,7 @@ type Query struct {
 	havingClauses           havingClauses
 	Paginator               *Paginator
 	Connection              *Connection
+	OptimizeCount           bool
 }
 
 // Clone will fill targetQ query with the connection used in q, if
@@ -41,6 +42,7 @@ func (q *Query) Clone(targetQ *Query) {
 	targetQ.groupClauses = q.groupClauses
 	targetQ.havingClauses = q.havingClauses
 	targetQ.addColumns = q.addColumns
+	targetQ.OptimizeCount = q.OptimizeCount
 
 	if q.Paginator != nil {
 		paginator := *q.Paginator

--- a/query.go
+++ b/query.go
@@ -180,10 +180,10 @@ func (q *Query) Limit(limit int) *Query {
 // Q will create a new "empty" query from the current connection.
 func Q(c *Connection) *Query {
 	return &Query{
-		RawSQL:      &clause{},
-		Connection:  c,
-		eager:       c.eager,
-		eagerFields: c.eagerFields,
+		RawSQL:        &clause{},
+		Connection:    c,
+		eager:         c.eager,
+		eagerFields:   c.eagerFields,
 		OptimizeCount: c.OptimizeCount,
 	}
 }

--- a/sql_builder.go
+++ b/sql_builder.go
@@ -218,6 +218,7 @@ func (sq *sqlBuilder) buildColumns() columns.Columns {
 	tableName := sq.Model.TableName()
 
 	asName := sq.Model.As
+	// If asName is not explicitly set and ignoreTableName is set, then don't us an AS name (alias)
 	if asName == "" && !sq.Model.ignoreTableName {
 		asName = strings.Replace(tableName, ".", "_", -1)
 	}

--- a/sql_builder.go
+++ b/sql_builder.go
@@ -216,10 +216,12 @@ var columnCacheMutex = sync.RWMutex{}
 
 func (sq *sqlBuilder) buildColumns() columns.Columns {
 	tableName := sq.Model.TableName()
+
 	asName := sq.Model.As
-	if asName == "" {
+	if asName == "" && !sq.Model.ignoreTableName {
 		asName = strings.Replace(tableName, ".", "_", -1)
 	}
+
 	acl := len(sq.AddColumns)
 	if acl == 0 {
 		columnCacheMutex.RLock()


### PR DESCRIPTION
#394 

This change allows for a query/connection to be configured to attempt to optimize how rows are counted by counting rows directly instead of counting rows in a derived table.