### PR TITLE
Migration runner and MigrationContent functions

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_LoadsConnectionsFromConfig(t *testing.T) {
 	r := require.New(t)
-  
+
 	r.NoError(LoadConfigFile())
 	if DialectSupported("sqlite3") {
 		r.Equal(5, len(Connections))

--- a/file_migrator.go
+++ b/file_migrator.go
@@ -26,7 +26,7 @@ func NewFileMigrator(path string, c *Connection) (FileMigrator, error) {
 		if err != nil {
 			return err
 		}
-		content, err := MigrationContent(mf, tx, f)
+		content, err := MigrationContent(mf, tx, f, true)
 		if err != nil {
 			return errors.Wrapf(err, "error processing %s", mf.Path)
 		}

--- a/file_migrator.go
+++ b/file_migrator.go
@@ -1,15 +1,9 @@
 package pop
 
 import (
-	"bytes"
-	"io"
-	"io/ioutil"
+	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
-	"text/template"
-
-	"github.com/gobuffalo/fizz"
-	"github.com/pkg/errors"
 )
 
 // FileMigrator is a migrator for SQL and Fizz
@@ -27,7 +21,26 @@ func NewFileMigrator(path string, c *Connection) (FileMigrator, error) {
 	}
 	fm.SchemaPath = path
 
-	err := fm.findMigrations()
+	runner := func(mf Migration, tx *Connection) error {
+		f, err := os.Open(mf.Path)
+		if err != nil {
+			return err
+		}
+		content, err := MigrationContent(mf, tx, f)
+		if err != nil {
+			return errors.Wrapf(err, "error processing %s", mf.Path)
+		}
+		if content == "" {
+			return nil
+		}
+		err = tx.RawQuery(content).Exec()
+		if err != nil {
+			return errors.Wrapf(err, "error executing %s, sql: %s", mf.Path, content)
+		}
+		return nil
+	}
+
+	err := fm.findMigrations(runner)
 	if err != nil {
 		return fm, err
 	}
@@ -35,7 +48,7 @@ func NewFileMigrator(path string, c *Connection) (FileMigrator, error) {
 	return fm, nil
 }
 
-func (fm *FileMigrator) findMigrations() error {
+func (fm *FileMigrator) findMigrations(runner func(mf Migration, tx *Connection) error) error {
 	dir := fm.Path
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
 		// directory doesn't exist
@@ -57,53 +70,11 @@ func (fm *FileMigrator) findMigrations() error {
 				DBType:    match.DBType,
 				Direction: match.Direction,
 				Type:      match.Type,
-				Runner: func(mf Migration, tx *Connection) error {
-					f, err := os.Open(p)
-					if err != nil {
-						return err
-					}
-					content, err := migrationContent(mf, tx, f)
-					if err != nil {
-						return errors.Wrapf(err, "error processing %s", mf.Path)
-					}
-
-					if content == "" {
-						return nil
-					}
-
-					err = tx.RawQuery(content).Exec()
-					if err != nil {
-						return errors.Wrapf(err, "error executing %s, sql: %s", mf.Path, content)
-					}
-					return nil
-				},
+				Runner:    runner,
 			}
 			fm.Migrations[mf.Direction] = append(fm.Migrations[mf.Direction], mf)
 		}
 		return nil
 	})
 	return nil
-}
-
-func migrationContent(mf Migration, c *Connection, r io.Reader) (string, error) {
-	b, err := ioutil.ReadAll(r)
-	if err != nil {
-		return "", nil
-	}
-
-	t := template.Must(template.New("sql").Parse(string(b)))
-	var bb bytes.Buffer
-	err = t.Execute(&bb, c.Dialect.Details())
-	if err != nil {
-		return "", errors.Wrapf(err, "could not execute migration template %s", mf.Path)
-	}
-	content := bb.String()
-
-	if mf.Type == "fizz" {
-		content, err = fizz.AString(content, c.Dialect.FizzTranslator())
-		if err != nil {
-			return "", errors.Wrapf(err, "could not fizz the migration %s", mf.Path)
-		}
-	}
-	return content, nil
 }

--- a/migration_box.go
+++ b/migration_box.go
@@ -22,7 +22,7 @@ func NewMigrationBox(box packd.Walkable, c *Connection) (MigrationBox, error) {
 
 	runner := func(f packd.File) func(mf Migration, tx *Connection) error {
 		return func(mf Migration, tx *Connection) error {
-			content, err := MigrationContent(mf, tx, f)
+			content, err := MigrationContent(mf, tx, f, true)
 			if err != nil {
 				return errors.Wrapf(err, "error processing %s", mf.Path)
 			}

--- a/migration_content.go
+++ b/migration_content.go
@@ -1,0 +1,35 @@
+package pop
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"text/template"
+
+	"github.com/gobuffalo/fizz"
+	"github.com/pkg/errors"
+)
+
+// MigrationContent returns the content of a migration.
+func MigrationContent(mf Migration, c *Connection, r io.Reader) (string, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return "", nil
+	}
+
+	t := template.Must(template.New("sql").Parse(string(b)))
+	var bb bytes.Buffer
+	err = t.Execute(&bb, c.Dialect.Details())
+	if err != nil {
+		return "", errors.Wrapf(err, "could not execute migration template %s", mf.Path)
+	}
+	content := bb.String()
+
+	if mf.Type == "fizz" {
+		content, err = fizz.AString(content, c.Dialect.FizzTranslator())
+		if err != nil {
+			return "", errors.Wrapf(err, "could not fizz the migration %s", mf.Path)
+		}
+	}
+	return content, nil
+}


### PR DESCRIPTION
This PR externalizes the logic in migration runners and the `migrationContent` function.  MigrationContent is now a public function with a flag to disable templating.  This PR simplifies the `findMigrations` functions so they can be overwritten more easily.