### PR TITLE
Search all valid paths for database.yml

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,8 +66,8 @@ func AddLookupPaths(paths ...string) error {
 
 func findConfigPath() (string, error) {
 	for _, p := range LookupPaths() {
+		path, _ := filepath.Abs(filepath.Join(p, ConfigName))
 		for {
-			path, _ := filepath.Abs(filepath.Join(p, ConfigName))
 			log(logging.Debug, "Looking for config at path %s", path)
 
 			// If our path is outside of any goPath, stop looking.

--- a/config.go
+++ b/config.go
@@ -68,6 +68,7 @@ func findConfigPath() (string, error) {
 	for pathPrepend := ""; ; {
 		for _, p := range LookupPaths() {
 			path, _ := filepath.Abs(filepath.Join(pathPrepend, p, ConfigName))
+			log(logging.Debug, "Looking for config at path %s", path)
 
 			// If our path is outside of any goPath, stop looking.
 			if !inGoPath(path) {

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ import (
 // after looking for it.
 var ErrConfigFileNotFound = errors.New("unable to find pop config file")
 
-var lookupPaths = []string{"", "./config", "config"}
+var lookupPaths = []string{"", "./config", "/config", "../", "../config", "../..", "../../config"}
 
 // ConfigName is the name of the YAML databases config file
 var ConfigName = "database.yml"


### PR DESCRIPTION
## Description

According to the [buffalo documentation](https://gobuffalo.io/en/docs/db/configuration/#database-yml) the `database.yml` file can be located in either `/config` or `/` at the project root.  The current implementation limits pop to a predefined set of lookup paths, which may or not actually include the project root based on the depth of the projects file structure.  This PR instead searches backwards for the nearest configuration, stopping once we leave GOPATH as at that point we have certainly left the project.

This was briefly mentioned in the #buffalo slack channel on July 2nd.

### Steps to Reproduce the Problem

Create a project which will use pop with the following project structure.

```
projectRoot/
projectRoot/database.yml
projectRoot/a/b/c/file.go
projectRoot/a/b/c/file_test.go
```

in file.go, attempt to call `pop.Connect(env)` in init.
run `go test ./...` from the project root.

### Expected Behavior

As the `database.yml` is at the project root, `pop.Connect` can find it automatically.

### Actual Behavior

You will get an `"unable to find pop config file"` error.  

### Workaround

You can workaround this using `pop.AddLookupPaths()`

### Info
Mac OS.
Latest Pop Development.

Needs testing on a windows environment.
