### PR TITLE
Allow for manually setting the CreatedAt field.

### DIFF
--- a/model.go
+++ b/model.go
@@ -145,9 +145,13 @@ func (m *Model) touchCreatedAt() {
 		now := time.Now()
 		switch fbn.Kind() {
 		case reflect.Int, reflect.Int64:
-			fbn.SetInt(now.Unix())
+			if fbn.Int() == 0 {
+				fbn.SetInt(now.Unix())
+			}
 		default:
-			fbn.Set(reflect.ValueOf(now))
+			if fbn.Interface().(time.Time).IsZero() {
+				fbn.Set(reflect.ValueOf(now))
+			}
 		}
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -73,6 +73,19 @@ func Test_Touch_Time_Timestamp(t *testing.T) {
 	r.NotZero(v.UpdatedAt)
 }
 
+func Test_Touch_Time_Timestamp_With_Existing_Value(t *testing.T) {
+	r := require.New(t)
+
+	createdAt := time.Now().Add(-36 * time.Hour)
+
+	m := Model{Value: &TimeTimestamp{CreatedAt: createdAt}}
+	m.touchCreatedAt()
+	m.touchUpdatedAt()
+	v := m.Value.(*TimeTimestamp)
+	r.Equal(createdAt, v.CreatedAt)
+	r.NotZero(v.UpdatedAt)
+}
+
 func Test_Touch_Unix_Timestamp(t *testing.T) {
 	r := require.New(t)
 
@@ -81,5 +94,18 @@ func Test_Touch_Unix_Timestamp(t *testing.T) {
 	m.touchUpdatedAt()
 	v := m.Value.(*UnixTimestamp)
 	r.NotZero(v.CreatedAt)
+	r.NotZero(v.UpdatedAt)
+}
+
+func Test_Touch_Unix_Timestamp_With_Existing_Value(t *testing.T) {
+	r := require.New(t)
+
+	createdAt := int(time.Now().Add(-36 * time.Hour).Unix())
+
+	m := Model{Value: &UnixTimestamp{CreatedAt: createdAt}}
+	m.touchCreatedAt()
+	m.touchUpdatedAt()
+	v := m.Value.(*UnixTimestamp)
+	r.Equal(createdAt, v.CreatedAt)
 	r.NotZero(v.UpdatedAt)
 }


### PR DESCRIPTION
For testing purposes there are situations where I'd like to be able to specify the value of the `CreatedAt` field instead of setting it to the current time. This PR updates the `touchCreatedAt` method to only set the field if it has a zero value.