### PR TITLE
Remove nanoseconds when touching updated at

### DIFF
--- a/model.go
+++ b/model.go
@@ -144,7 +144,7 @@ func (m *Model) setID(i interface{}) {
 func (m *Model) touchCreatedAt() {
 	fbn, err := m.fieldByName("CreatedAt")
 	if err == nil {
-		now := time.Unix(nowFunc().Unix(), 0)
+		now := nowFunc().Truncate(time.Microsecond)
 		v := fbn.Interface()
 		if !IsZeroOfUnderlyingType(v) {
 			// Do not override already set CreatedAt
@@ -162,7 +162,7 @@ func (m *Model) touchCreatedAt() {
 func (m *Model) touchUpdatedAt() {
 	fbn, err := m.fieldByName("UpdatedAt")
 	if err == nil {
-		now := time.Unix(nowFunc().Unix(), 0)
+		now := nowFunc().Truncate(time.Microsecond)
 		v := fbn.Interface()
 		switch v.(type) {
 		case int, int64:

--- a/soda/cmd/generate/model_templates.go
+++ b/soda/cmd/generate/model_templates.go
@@ -11,6 +11,7 @@ import (
 	{{ end -}}
 )
 
+// {{.model_name}} model struct
 type {{.model_name}} struct {
 	{{range $a := .model.Attributes -}}
 	{{$a}}


### PR DESCRIPTION
When you update a model, the `updated_at` field contains nanoseconds. But these nanoseconds are not stored in the database. So when you fetch the model again from the database does not contain the nanoseconds. This can lead to weird situations for clients. 

For example, a iOS app sends a PUT request to update a certain model and stores the result. The `updated_at` field is `2019-07-20T10:36:19.819375Z`. Later, when re-fetching the result from the API it returns a different response (because the `updated_at` field is now `2019-07-20T10:36:19Z`). This leads to weird situations. Also, Swift doesn't understand the nanoseconds.

PS: I couldn't find a better way to remove the nanoseconds. 