### PR TITLE
Allow setting connection max lifetime

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -107,6 +107,9 @@ func (c *Connection) Open() error {
 	if details.IdlePool != 0 {
 		db.SetMaxIdleConns(details.IdlePool)
 	}
+	if details.ConnMaxLifetime > 0 {
+		db.SetConnMaxLifetime(details.ConnMaxLifetime)
+	}
 	c.Store = &dB{db}
 
 	if d, ok := c.Dialect.(afterOpenable); ok {

--- a/connection_details.go
+++ b/connection_details.go
@@ -41,7 +41,9 @@ type ConnectionDetails struct {
 	Pool int
 	// Defaults to 2. See https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 	IdlePool int
-	Options  map[string]string
+	// Defaults to 0 "unlimited". See https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime
+	ConnMaxLifetime time.Duration
+	Options         map[string]string
 	// Query string encoded options from URL. Example: "sslmode=disable"
 	RawOptions string
 }


### PR DESCRIPTION
I'd like to be able to set the maximum lifetime on a DB connection. My use case is that I'm authenticating to the DB using AWS IAM roles which have tokens that expire every 15 minutes. So my connection shouldn't last longer that that time before I need to generate a new token and a new connection. 

I am writing this PR because I can't seem to do this and it seemed easier to contribute back: 

```go
if db, ok := connection.Store.(*pop.dB); ok {
  sqlxDB := db.DB
  sqlxDB.SetConnMaxLifetime(10 * time.Minute)
}
```
