### PR TITLE
Fixed column order

### DIFF
--- a/columns/columns.go
+++ b/columns/columns.go
@@ -118,37 +118,41 @@ func (c Columns) Readable() *ReadableColumns {
 	return w
 }
 
+// colNames returns a slice of column names in a deterministic order
+func (c Columns) colNames() []string {
+	var xs []string
+	for _, t := range c.Cols {
+		xs = append(xs, t.Name)
+	}
+	sort.Strings(xs)
+	return xs
+}
+
 type quoter interface {
 	Quote(key string) string
 }
 
 // QuotedString gives the columns list quoted with the given quoter function.
 func (c Columns) QuotedString(quoter quoter) string {
-	var xs []string
-	for _, t := range c.Cols {
-		xs = append(xs, quoter.Quote(t.Name))
+	xs := c.colNames()
+	for i, n := range xs {
+		xs[i] = quoter.Quote(n)
 	}
-	sort.Strings(xs)
 	return strings.Join(xs, ", ")
 }
 
 func (c Columns) String() string {
-	var xs []string
-	for _, t := range c.Cols {
-		xs = append(xs, t.Name)
-	}
-	sort.Strings(xs)
+	xs := c.colNames()
 	return strings.Join(xs, ", ")
 }
 
 // SymbolizedString returns a list of tokens (:token) to bind
 // a value to an INSERT query.
 func (c Columns) SymbolizedString() string {
-	var xs []string
-	for _, t := range c.Cols {
-		xs = append(xs, ":"+t.Name)
+	xs := c.colNames()
+	for i, n := range xs {
+		xs[i] = ":" + n
 	}
-	sort.Strings(xs)
 	return strings.Join(xs, ", ")
 }
 

--- a/columns/columns_test.go
+++ b/columns/columns_test.go
@@ -1,6 +1,7 @@
 package columns_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gobuffalo/pop/columns"
@@ -59,4 +60,24 @@ func Test_Columns_Remove(t *testing.T) {
 		c.Remove("foo", "first_name")
 		r.Equal(len(c.Cols), 3)
 	}
+}
+
+type fooWithSuffix struct {
+	Amount      float64 `db:"amount"`
+	AmountUnits string  `db:"amount_units"`
+}
+type fooQuoter struct{}
+
+func (fooQuoter) Quote(key string) string {
+	return fmt.Sprintf("`%v`", key)
+}
+
+func Test_Columns_Sorted(t *testing.T) {
+	r := require.New(t)
+
+	c := columns.ForStruct(fooWithSuffix{}, "fooWithSuffix")
+	r.Equal(len(c.Cols), 2)
+	r.Equal(c.SymbolizedString(), ":amount, :amount_units")
+	r.Equal(c.String(), "amount, amount_units")
+	r.Equal(c.QuotedString(fooQuoter{}), "`amount`, `amount_units`")
 }


### PR DESCRIPTION
Resolves #429

Adds a `colNames` function that returns a `[]string` sorted. This allows the column names to be modified before being strung together, while ensuring that weird quirks don't cause them to be sorted in a different way. For example: `"a" < "a_" < "a``"`