### PR TITLE
 Upgrade goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,8 @@
 # Edit .goreleaser.yml.plush instead
 
 builds:
-- binary: soda
+- id: pop_darwin
+  binary: soda
   main: soda/main.go
   goos:
     - darwin
@@ -16,7 +17,8 @@ builds:
     - -tags
     - sqlite
 
-- binary: soda
+- id: pop_linux
+  binary: soda
   main: soda/main.go
   env:
     - CGO_ENABLED=1
@@ -29,7 +31,8 @@ builds:
     - amd64
     - 386
 
-- binary: soda
+- id: pop_windows_i686
+  binary: soda
   main: soda/main.go
   ldflags:
     - "-extldflags '-static'"
@@ -45,7 +48,8 @@ builds:
   goarch:
     - 386
 
-- binary: soda
+- id: pop_windows_x64
+  binary: soda
   main: soda/main.go
   ldflags:
     - "-extldflags '-static'"
@@ -61,11 +65,11 @@ builds:
   goarch:
     - amd64
 
-archive:
-  format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  -
+    format_overrides:
+      - goos: windows
+        format: zip
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,7 +84,11 @@ changelog:
       - '^docs:'
       - '^test:'
 
-brew:
-  github:
-    owner: gobuffalo
-    name: homebrew-tap
+brews:
+  -
+    github:
+      owner: gobuffalo
+      name: homebrew-tap
+    homepage: "https://gobuffalo.io/docs/db/getting-started"
+    description: "A Tasty Treat For All Your Database Needs"
+    skip_upload: "auto"

--- a/.goreleaser.yml.plush
+++ b/.goreleaser.yml.plush
@@ -1,5 +1,6 @@
 builds:
-- binary: soda
+- id: pop_darwin
+  binary: soda
   main: soda/main.go
   goos:
     - darwin
@@ -13,7 +14,8 @@ builds:
     - -tags
     - sqlite
 
-- binary: soda
+- id: pop_linux
+  binary: soda
   main: soda/main.go
   env:
     - CGO_ENABLED=1
@@ -26,7 +28,8 @@ builds:
     - amd64
     - 386
 
-- binary: soda
+- id: pop_windows_i686
+  binary: soda
   main: soda/main.go
   ldflags:
     - "-extldflags '-static'"
@@ -42,7 +45,8 @@ builds:
   goarch:
     - 386
 
-- binary: soda
+- id: pop_windows_x64
+  binary: soda
   main: soda/main.go
   ldflags:
     - "-extldflags '-static'"
@@ -58,11 +62,11 @@ builds:
   goarch:
     - amd64
 
-archive:
-  format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  -
+    format_overrides:
+      - goos: windows
+        format: zip
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml.plush
+++ b/.goreleaser.yml.plush
@@ -81,8 +81,12 @@ changelog:
       - '^docs:'
       - '^test:'
 <%= if (brew) { %>
-brew:
-  github:
-    owner: gobuffalo
-    name: homebrew-tap
+brews:
+  -
+    github:
+      owner: gobuffalo
+      name: homebrew-tap
+    homepage: "https://gobuffalo.io/docs/db/getting-started"
+    description: "A Tasty Treat For All Your Database Needs"
+    skip_upload: "auto"
 <% } %>


### PR DESCRIPTION
Goreleaser now requires IDs for distinct builds.

Also improve the brew formula to be aware of beta releases.