### PR TITLE
Fix escape quote function

### DIFF
--- a/dialect_common.go
+++ b/dialect_common.go
@@ -31,7 +31,16 @@ func (commonDialect) Lock(fn func() error) error {
 }
 
 func (commonDialect) Quote(key string) string {
-	return fmt.Sprintf(`"%s"`, key)
+	parts := strings.Split(key, ".")
+
+	for i, part := range parts {
+		part = strings.Trim(part, `"`)
+		part = strings.TrimSpace(part)
+
+		parts[i] = fmt.Sprintf(`"%v"`, part)
+	}
+
+	return strings.Join(parts, ".")
 }
 
 func genericCreate(s store, model *Model, cols columns.Columns, quoter quotable) error {

--- a/dialect_postgresql_test.go
+++ b/dialect_postgresql_test.go
@@ -79,3 +79,12 @@ func Test_PostgreSQL_Connection_String_Failure(t *testing.T) {
 	r.Error(err)
 	r.Equal("postgres", cd.Dialect)
 }
+
+func Test_PostgreSQL_Quotable(t *testing.T) {
+	r := require.New(t)
+	p := postgresql{}
+
+	r.Equal(`"table_name"`, p.Quote("table_name"))
+	r.Equal(`"schema"."table_name"`, p.Quote("schema.table_name"))
+	r.Equal(`"schema"."table name"`, p.Quote(`"schema"."table name"`))
+}


### PR DESCRIPTION
Problem
Update and Delete are not working with tables name that have schema ("schema.table_name")

Behavior
Actual:
```sql
UPDATE "schema.table_name" SET...
```
Generate psql error

Expected:
```sql
UPDATE "schema"."table_name" SET...
```

DB used to test:
PostgreSQL 9.6