### PR TITLE
Add callback before validate

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -97,6 +97,20 @@ func (m *Model) beforeDestroy(c *Connection) error {
 	return nil
 }
 
+// BeforeValidateable callback will be called before a record is
+// validated during
+// ValidateAndCreate, ValidateAndUpdate, or ValidateAndSave
+type BeforeValidateable interface {
+	BeforeValidate(*Connection) error
+}
+
+func (m *Model) beforeValidate(c *Connection) error {
+	if x, ok := m.Value.(BeforeValidateable); ok {
+		return x.BeforeValidate(c)
+	}
+	return nil
+}
+
 // AfterDestroyable callback will be called after a record is
 // destroyed in the database.
 type AfterDestroyable interface {

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -18,6 +18,7 @@ func Test_Callbacks(t *testing.T) {
 			BeforeC: "BC",
 			BeforeU: "BU",
 			BeforeD: "BD",
+			BeforeV: "BV",
 			AfterS:  "AS",
 			AfterC:  "AC",
 			AfterU:  "AU",
@@ -50,6 +51,10 @@ func Test_Callbacks(t *testing.T) {
 		r.Equal("BeforeDestroy", user.BeforeD)
 		r.Equal("AfterDestroy", user.AfterD)
 
+		verrs, err := tx.ValidateAndSave(user)
+		r.False(verrs.HasAny())
+		r.NoError(err)
+		r.Equal("BeforeValidate", user.BeforeV)
 	})
 }
 

--- a/executors.go
+++ b/executors.go
@@ -52,6 +52,9 @@ func (q *Query) ExecWithCount() (int, error) {
 // If model is a slice, each item of the slice is validated then saved in the database.
 func (c *Connection) ValidateAndSave(model interface{}, excludeColumns ...string) (*validate.Errors, error) {
 	sm := &Model{Value: model}
+	if err := sm.beforeValidate(c); err != nil {
+		return nil, err
+	}
 	verrs, err := sm.validateSave(c)
 	if err != nil {
 		return verrs, err
@@ -93,6 +96,9 @@ func (c *Connection) Save(model interface{}, excludeColumns ...string) error {
 // If model is a slice, each item of the slice is validated then created in the database.
 func (c *Connection) ValidateAndCreate(model interface{}, excludeColumns ...string) (*validate.Errors, error) {
 	sm := &Model{Value: model}
+	if err := sm.beforeValidate(c); err != nil {
+		return nil, err
+	}
 	verrs, err := sm.validateCreate(c)
 	if err != nil {
 		return verrs, err
@@ -313,6 +319,9 @@ func (c *Connection) Create(model interface{}, excludeColumns ...string) error {
 // If model is a slice, each item of the slice is validated then updated in the database.
 func (c *Connection) ValidateAndUpdate(model interface{}, excludeColumns ...string) (*validate.Errors, error) {
 	sm := &Model{Value: model}
+	if err := sm.beforeValidate(c); err != nil {
+		return nil, err
+	}
 	verrs, err := sm.validateUpdate(c)
 	if err != nil {
 		return verrs, err

--- a/migrations/20181104135800_callbacks_users.up.fizz
+++ b/migrations/20181104135800_callbacks_users.up.fizz
@@ -9,5 +9,6 @@ create_table("callbacks_users") {
   t.Column("after_u", "string", {})
   t.Column("after_d", "string", {})
   t.Column("after_f", "string", {})
+  t.Column("before_v", "string", {})
   t.Timestamps()
 }

--- a/pop_test.go
+++ b/pop_test.go
@@ -287,6 +287,7 @@ type CallbacksUser struct {
 	BeforeC   string    `db:"before_c"`
 	BeforeU   string    `db:"before_u"`
 	BeforeD   string    `db:"before_d"`
+	BeforeV   string    `db:"before_v"`
 	AfterS    string    `db:"after_s"`
 	AfterC    string    `db:"after_c"`
 	AfterU    string    `db:"after_u"`
@@ -315,6 +316,11 @@ func (u *CallbacksUser) BeforeCreate(tx *Connection) error {
 
 func (u *CallbacksUser) BeforeDestroy(tx *Connection) error {
 	u.BeforeD = "BeforeDestroy"
+	return nil
+}
+
+func (u *CallbacksUser) BeforeValidate(tx *Connection) error {
+	u.BeforeV = "BeforeValidate"
 	return nil
 }
 


### PR DESCRIPTION
Add a callback to be run prior to validation.

Existing callbacks are all run after validation, so callback based changes to models can't be included in validation.

Example use case:
Password hashing in BeforeValidate, allowing validation to be run on it to make sure it is present on a user.