### PR TITLE
Improve tests and documentation for UpdateColumns function

### DIFF
--- a/executors.go
+++ b/executors.go
@@ -373,7 +373,7 @@ func (c *Connection) Update(model interface{}, excludeColumns ...string) error {
 
 // UpdateColumns writes changes from an entry to the database, including only the given columns
 // or all columns if no column names are provided.
-// It updates the `updated_at` column automatically.
+// It updates the `updated_at` column automatically if you include `updated_at` in columnNames.
 //
 // If model is a slice, each item of the slice is updated in the database.
 func (c *Connection) UpdateColumns(model interface{}, columnNames ...string) error {

--- a/executors_test.go
+++ b/executors_test.go
@@ -1253,6 +1253,29 @@ func Test_UpdateColumns(t *testing.T) {
 	})
 }
 
+func Test_UpdateColumns_UpdatedAt(t *testing.T) {
+	if PDB == nil {
+		t.Skip("skipping integration tests")
+	}
+	transaction(func(tx *Connection) {
+		r := require.New(t)
+
+		user := User{Name: nulls.NewString("Foo")}
+		tx.Create(&user)
+
+		r.NotZero(user.CreatedAt)
+		r.NotZero(user.UpdatedAt)
+		updatedAtBefore := user.UpdatedAt
+
+		user.Name.String = "Bar"
+		err := tx.UpdateColumns(&user, "name", "updated_at") // Update name and updated_at
+		r.NoError(err)
+
+		r.NoError(tx.Reload(&user))
+		r.NotEqual(user.UpdatedAt, updatedAtBefore) // UpdatedAt should be updated automatically
+	})
+}
+
 func Test_UpdateColumns_MultipleColumns(t *testing.T) {
 	if PDB == nil {
 		t.Skip("skipping integration tests")


### PR DESCRIPTION
In the documentation it states that `UpdateColumns()` updates the `updated_at` field automatically. This is slightly confusing because apparently you still need to include `updated_at` as a parameter for the function. This commit tries to clarify the ambiguity and also adds a test for `updated_at` field