### PR TITLE
Add ability to pass down context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,10 @@
+package pop
+
+import "context"
+
+func contextOrBackground(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}

--- a/db.go
+++ b/db.go
@@ -13,7 +13,7 @@ type dB struct {
 }
 
 func (db *dB) TransactionContext(context.Context) (*Tx, error) {
-	return newTX(context.Background(), db)
+	return newTX(ctx, db)
 }
 
 func (db *dB) Transaction() (*Tx, error) {

--- a/db.go
+++ b/db.go
@@ -1,13 +1,23 @@
 package pop
 
-import "github.com/jmoiron/sqlx"
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var _ store = new(dB)
 
 type dB struct {
 	*sqlx.DB
 }
 
+func (db *dB) TransactionContext(context.Context) (*Tx, error) {
+	return newTX(context.Background(), db)
+}
+
 func (db *dB) Transaction() (*Tx, error) {
-	return newTX(db)
+	return newTX(context.Background(), db)
 }
 
 func (db *dB) Rollback() error {

--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -1,6 +1,7 @@
 package pop
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -61,7 +62,7 @@ func (p *cockroach) Details() *ConnectionDetails {
 	return p.ConnectionDetails
 }
 
-func (p *cockroach) Create(s store, model *Model, cols columns.Columns) error {
+func (p *cockroach) Create(ctx context.Context, s store, model *Model, cols columns.Columns) error {
 	keyType := model.PrimaryKeyType()
 	switch keyType {
 	case "int", "int64":

--- a/store.go
+++ b/store.go
@@ -1,6 +1,7 @@
 package pop
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/jmoiron/sqlx"
@@ -10,11 +11,23 @@ import (
 // to be able to use the value as a way of talking to a datastore.
 type store interface {
 	Select(interface{}, string, ...interface{}) error
+	SelectContext(context.Context, interface{}, string, ...interface{}) error
+
 	Get(interface{}, string, ...interface{}) error
+	GetContext(context.Context,interface{}, string, ...interface{}) error
+
 	NamedExec(string, interface{}) (sql.Result, error)
+	NamedExecContext(context.Context,string, interface{}) (sql.Result, error)
+
 	Exec(string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context,string, ...interface{}) (sql.Result, error)
+
 	PrepareNamed(string) (*sqlx.NamedStmt, error)
+	PrepareNamedContext(context.Context,string) (*sqlx.NamedStmt, error)
+
 	Transaction() (*Tx, error)
+	TransactionContext(context.Context) (*Tx, error)
+
 	Rollback() error
 	Commit() error
 	Close() error

--- a/tx.go
+++ b/tx.go
@@ -1,6 +1,7 @@
 package pop
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -18,11 +19,11 @@ type Tx struct {
 	*sqlx.Tx
 }
 
-func newTX(db *dB) (*Tx, error) {
+func newTX(ctx context.Context, db *dB) (*Tx, error) {
 	t := &Tx{
 		ID: rand.Int(),
 	}
-	tx, err := db.Beginx()
+	tx, err := db.BeginTxx(ctx,nil)
 	t.Tx = tx
 	return t, errors.Wrap(err, "could not create new transaction")
 }


### PR DESCRIPTION
Both `sql` and `sqlx` support the ability to pass down context. This is important for use cases where the context is used for instrumentation (metrics) and tracing. Without that ability, it can become very difficult to find and resolve issues in production deployments.

This is just a draft. I first wanted to get feedback from maintainers that this is something that would be considered to be merged. Also, help would be appreciated.

 Closes #251
