### PR TITLE
Cockroach URL scheme is now postgres

### DIFF
--- a/dialect_cockroach_test.go
+++ b/dialect_cockroach_test.go
@@ -20,6 +20,18 @@ func Test_Cockroach_URL_Raw(t *testing.T) {
 	r.Equal("postgres://user:pass@host:1337/?option1=value1", m.urlWithoutDb())
 }
 
+func Test_Cockroach_URL_Only(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		URL: "cockroach://user:pass@host:1337/database?option1=value1",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	m := &cockroach{commonDialect: commonDialect{ConnectionDetails: cd}}
+	r.Equal("postgres://user:pass@host:1337/database?option1=value1", m.URL())
+	r.Equal("postgres://user:pass@host:1337/?option1=value1", m.urlWithoutDb())
+}
+
 func Test_Cockroach_URL_Build(t *testing.T) {
 	r := require.New(t)
 

--- a/packrd/packed-packr.go
+++ b/packrd/packed-packr.go
@@ -39,15 +39,13 @@ var _ = func() error {
 		b.SetResolver("-name-/options.go.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "e23171fc37a4565aaac143176b307056"})
 		b.SetResolver("-name-/options_test.go.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "91d30953d7167b4a010b13c730a7f775"})
 		b.SetResolver("-name-/templates/example.txt.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "5342f4924f2b8ea377a6a4ca790eb6ef"})
-		}()
-
+	}()
 
 	func() {
 		b := packr.New("github.com/gobuffalo/pop/genny/model/templates", "../model/templates")
 		b.SetResolver("-path-/-name-.go.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "3699b8e306d86894bcec8f964ef67637"})
 		b.SetResolver("-path-/-name-_test.go.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "e3c90027f4b4c5c390d3f30e0d11280f"})
-		}()
-
+	}()
 
 	func() {
 		b := packr.New("pop:genny:config", "../config/templates")
@@ -56,7 +54,7 @@ var _ = func() error {
 		b.SetResolver("mysql.yml.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "9a662f20e59b4883438e80281d1534dc"})
 		b.SetResolver("postgres.yml.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "58b9703b1628778f140488b5a31f3b7c"})
 		b.SetResolver("sqlite3.yml.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "47e2a1af06185b6b7069039e642b7ff6"})
-		}()
+	}()
 
 	return nil
 }()


### PR DESCRIPTION
Before this patch, when using a raw URL connection string such as
`crdb://foo/baz`, the cockroach dialect would not replace it with
`postgres://`. This causes an issue where the `lib/pq` driver
completely ignores the URL and simply falls back to the defaults
(localhost, 5432).

This patch changes that, by replacing `cockroach` (and aliases)
with `postgres` when returning the URL.