### PR TITLE
Add context.Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tsoda
 testdata/migrations/schema.sql
 .grifter/
 vendor/
+.env
 
 # test data
 cockroach-data/

--- a/connection.go
+++ b/connection.go
@@ -184,11 +184,9 @@ func (c *Connection) NewTransaction() (*Connection, error) {
 
 func (c *Connection) Ctx(ctx context.Context) *Connection {
 	cn := c.copy()
-	if sc, ok := cn.Store.(storeContext); ok {
-		cn.Store = contextStore{
-			storeContext: sc,
-			ctx:          ctx,
-		}
+	cn.Store = contextStore{
+		store: cn.Store,
+		ctx:   ctx,
 	}
 	return cn
 }

--- a/connection.go
+++ b/connection.go
@@ -188,7 +188,8 @@ func (c *Connection) NewTransaction() (*Connection, error) {
 	return cn, nil
 }
 
-func (c *Connection) Ctx(ctx context.Context) *Connection {
+// WithContext returns a copy of the connection, wrapped with a context.
+func (c *Connection) WithContext(ctx context.Context) *Connection {
 	cn := c.copy()
 	cn.Store = contextStore{
 		store: cn.Store,

--- a/connection.go
+++ b/connection.go
@@ -1,6 +1,7 @@
 package pop
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -179,6 +180,17 @@ func (c *Connection) NewTransaction() (*Connection, error) {
 		cn = c
 	}
 	return cn, nil
+}
+
+func (c *Connection) Ctx(ctx context.Context) *Connection {
+	cn := c.copy()
+	if sc, ok := cn.Store.(storeContext); ok {
+		cn.Store = contextStore{
+			storeContext: sc,
+			ctx:          ctx,
+		}
+	}
+	return cn
 }
 
 func (c *Connection) copy() *Connection {

--- a/connection.go
+++ b/connection.go
@@ -170,9 +170,15 @@ func (c *Connection) NewTransaction() (*Connection, error) {
 		if err != nil {
 			return cn, errors.Wrap(err, "couldn't start a new transaction")
 		}
+		var store store = tx
+
+		// Rewrap the store if it was a context store
+		if cs, ok := c.Store.(contextStore); ok {
+			store = contextStore{store: store, ctx: cs.ctx}
+		}
 		cn = &Connection{
 			ID:      randx.String(30),
-			Store:   tx,
+			Store:   store,
 			Dialect: c.Dialect,
 			TX:      tx,
 		}

--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -10,7 +10,7 @@ func Test_ConnectionDetails_Finalize(t *testing.T) {
 	r := require.New(t)
 
 	cd := &ConnectionDetails{
-		URL: "postgres://user:pass@host:1337/database",
+		URL: "postgres://user:pass@host:1234/database",
 	}
 	err := cd.Finalize()
 	r.NoError(err)
@@ -19,14 +19,14 @@ func Test_ConnectionDetails_Finalize(t *testing.T) {
 	r.Equal("postgres", cd.Dialect)
 	r.Equal("host", cd.Host)
 	r.Equal("pass", cd.Password)
-	r.Equal("1337", cd.Port)
+	r.Equal("1234", cd.Port)
 	r.Equal("user", cd.User)
 }
 
 func Test_ConnectionDetails_Finalize_MySQL_Standard(t *testing.T) {
 	r := require.New(t)
 
-	url := "mysql://user:pass@(host:port)/database?param1=value1&param2=value2"
+	url := "mysql://user:pass@(host:1234)/database?param1=value1&param2=value2"
 	cd := &ConnectionDetails{
 		URL: url,
 	}
@@ -38,7 +38,7 @@ func Test_ConnectionDetails_Finalize_MySQL_Standard(t *testing.T) {
 	r.Equal("user", cd.User)
 	r.Equal("pass", cd.Password)
 	r.Equal("host", cd.Host)
-	r.Equal("port", cd.Port)
+	r.Equal("1234", cd.Port)
 	r.Equal("database", cd.Database)
 }
 
@@ -46,14 +46,14 @@ func Test_ConnectionDetails_Finalize_Cockroach(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
 		Dialect: "cockroach",
-		URL:     "postgres://user:pass@host:1337/database?sslmode=require&sslrootcert=certs/ca.crt&sslkey=certs/client.key&sslcert=certs/client.crt",
+		URL:     "postgres://user:pass@host:1234/database?sslmode=require&sslrootcert=certs/ca.crt&sslkey=certs/client.key&sslcert=certs/client.crt",
 	}
 	err := cd.Finalize()
 	r.NoError(err)
 	r.Equal("cockroach", cd.Dialect)
 	r.Equal("database", cd.Database)
 	r.Equal("host", cd.Host)
-	r.Equal("1337", cd.Port)
+	r.Equal("1234", cd.Port)
 	r.Equal("user", cd.User)
 	r.Equal("pass", cd.Password)
 }
@@ -61,7 +61,7 @@ func Test_ConnectionDetails_Finalize_Cockroach(t *testing.T) {
 func Test_ConnectionDetails_Finalize_UnknownSchemeURL(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
-		URL: "unknown://user:pass@host:port/database",
+		URL: "unknown://user:pass@host:1234/database",
 	}
 	err := cd.Finalize()
 	r.Error(err)

--- a/connection_details_test.go
+++ b/connection_details_test.go
@@ -26,7 +26,7 @@ func Test_ConnectionDetails_Finalize(t *testing.T) {
 func Test_ConnectionDetails_Finalize_MySQL_Standard(t *testing.T) {
 	r := require.New(t)
 
-	url := "mysql://user:pass@(host:1234)/database?param1=value1&param2=value2"
+	url := "mysql://user:pass@(host:1337)/database?param1=value1&param2=value2"
 	cd := &ConnectionDetails{
 		URL: url,
 	}
@@ -38,7 +38,7 @@ func Test_ConnectionDetails_Finalize_MySQL_Standard(t *testing.T) {
 	r.Equal("user", cd.User)
 	r.Equal("pass", cd.Password)
 	r.Equal("host", cd.Host)
-	r.Equal("1234", cd.Port)
+	r.Equal("1337", cd.Port)
 	r.Equal("database", cd.Database)
 }
 
@@ -61,7 +61,7 @@ func Test_ConnectionDetails_Finalize_Cockroach(t *testing.T) {
 func Test_ConnectionDetails_Finalize_UnknownSchemeURL(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
-		URL: "unknown://user:pass@host:1234/database",
+		URL: "unknown://user:pass@host:1337/database",
 	}
 	err := cd.Finalize()
 	r.Error(err)

--- a/db.go
+++ b/db.go
@@ -1,13 +1,21 @@
 package pop
 
-import "github.com/jmoiron/sqlx"
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+)
 
 type dB struct {
 	*sqlx.DB
 }
 
+func (db *dB) TransactionContext(ctx context.Context) (*Tx, error) {
+	return newTX(ctx, db)
+}
+
 func (db *dB) Transaction() (*Tx, error) {
-	return newTX(db)
+	return newTX(context.Background(), db)
 }
 
 func (db *dB) Rollback() error {

--- a/dialect_cockroach_test.go
+++ b/dialect_cockroach_test.go
@@ -11,13 +11,13 @@ func Test_Cockroach_URL_Raw(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
 		Dialect: "cockroach",
-		URL:     "scheme://user:pass@host:1337/database?option1=value1",
+		URL:     "scheme://user:pass@host:1234/database?option1=value1",
 	}
 	err := cd.Finalize()
 	r.NoError(err)
 	m := &cockroach{commonDialect: commonDialect{ConnectionDetails: cd}}
-	r.Equal("scheme://user:pass@host:1337/database?option1=value1", m.URL())
-	r.Equal("postgres://user:pass@host:1337/?option1=value1", m.urlWithoutDb())
+	r.Equal("scheme://user:pass@host:1234/database?option1=value1", m.URL())
+	r.Equal("postgres://user:pass@host:1234/?option1=value1", m.urlWithoutDb())
 }
 
 func Test_Cockroach_URL_Build(t *testing.T) {

--- a/tx.go
+++ b/tx.go
@@ -1,6 +1,7 @@
 package pop
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -18,13 +19,19 @@ type Tx struct {
 	*sqlx.Tx
 }
 
-func newTX(db *dB) (*Tx, error) {
+func newTX(ctx context.Context, db *dB) (*Tx, error) {
 	t := &Tx{
 		ID: rand.Int(),
 	}
-	tx, err := db.Beginx()
+	tx, err := db.BeginTxx(ctx, nil)
 	t.Tx = tx
 	return t, errors.Wrap(err, "could not create new transaction")
+}
+
+// TransactionContext simply returns the current transaction,
+// this is defined so it implements the `Store` interface.
+func (tx *Tx) TransactionContext(ctx context.Context) (*Tx, error) {
+	return tx, nil
 }
 
 // Transaction simply returns the current transaction,


### PR DESCRIPTION
The implementation may work, but I haven't been able to test it and won't for some time. It does compile and existing tests still work (last I checked before merging development in).

If someone would like to verify this works, this could get merged in.

Additionally it would probably be beneficial to add this to the middleware in Buffalo to append the context on the tx in the context.

This PR is a rebased version of #472.