### PR TITLE
Cockroach URL scheme is now postgres

### DIFF
--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -262,6 +262,17 @@ func finalizerCockroach(cd *ConnectionDetails) {
 	appName := filepath.Base(os.Args[0])
 	cd.Options["application_name"] = defaults.String(cd.Options["application_name"], appName)
 	cd.Port = defaults.String(cd.Port, portCockroach)
+	if cd.URL != "" {
+		cd.URL = "postgres://" + trimCockroachPrefix(cd.URL)
+	}
+}
+
+func trimCockroachPrefix(u string) string {
+	parts := strings.Split(u, "://")
+	if len(parts) != 2 {
+		return u
+	}
+	return parts[1]
 }
 
 func (p *cockroach) tablesQuery() string {

--- a/dialect_cockroach_test.go
+++ b/dialect_cockroach_test.go
@@ -11,12 +11,12 @@ func Test_Cockroach_URL_Raw(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
 		Dialect: "cockroach",
-		URL:     "scheme://user:pass@host:1234/database?option1=value1",
+		URL:     "cockroach://user:pass@host:1234/database?option1=value1",
 	}
 	err := cd.Finalize()
 	r.NoError(err)
 	m := &cockroach{commonDialect: commonDialect{ConnectionDetails: cd}}
-	r.Equal("scheme://user:pass@host:1234/database?option1=value1", m.URL())
+	r.Equal("postgres://user:pass@host:1234/database?option1=value1", m.URL())
 	r.Equal("postgres://user:pass@host:1234/?option1=value1", m.urlWithoutDb())
 }
 
@@ -84,4 +84,16 @@ func Test_Cockroach_tableQuery(t *testing.T) {
 
 	cr.info.version = "v20.1.1"
 	r.Equal(selectTablesQueryCockroach, cr.tablesQuery())
+}
+
+func Test_Cockroach_URL_Only(t *testing.T) {
+	r := require.New(t)
+	cd := &ConnectionDetails{
+		URL: "cockroach://user:pass@host:1337/database?option1=value1",
+	}
+	err := cd.Finalize()
+	r.NoError(err)
+	m := &cockroach{commonDialect: commonDialect{ConnectionDetails: cd}}
+	r.Equal("postgres://user:pass@host:1337/database?option1=value1", m.URL())
+	r.Equal("postgres://user:pass@host:1337/?option1=value1", m.urlWithoutDb())
 }


### PR DESCRIPTION
Before this patch, when using a raw URL connection string such as
`crdb://foo/baz`, the cockroach dialect would not replace it with
`postgres://`. This causes an issue where the `lib/pq` driver
completely ignores the URL and simply falls back to the defaults
(localhost, 5432).

This patch changes that, by replacing `cockroach` (and aliases)
with `postgres` when returning the URL.