### PR TITLE
Add a markbates/pkger migrator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/jackc/pgconn v1.1.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.2.0
+	github.com/markbates/pkger v0.12.10
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mattn/go-sqlite3 v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
+github.com/markbates/pkger v0.12.10 h1:prh1H4VLkDKyPThBKlv4FwotLmcs3g9xFsCLV4c2G8M=
+github.com/markbates/pkger v0.12.10/go.mod h1:C7e5A6bnWZT+nXkUwkvysGW7sxl/IGd63HEa6N/JY8s=
 github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -291,5 +293,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkger_migrator.go
+++ b/pkger_migrator.go
@@ -57,10 +57,8 @@ func (fm *PkgerMigrator) findMigrations(runner func(mf Migration, tx *Connection
 		return nil
 	}
 	return pkger.Walk(dir, func(p string, info os.FileInfo, err error) error {
-		//	fmt.Printf("walking %v: %v", p, info)
 		if !info.IsDir() {
 			match, err := ParseMigrationFilename(info.Name())
-			//		fmt.Printf("match: %v, err: %v", match, err)
 			if err != nil {
 				return err
 			}

--- a/pkger_migrator.go
+++ b/pkger_migrator.go
@@ -1,0 +1,83 @@
+package pop
+
+import (
+	"os"
+
+	"github.com/markbates/pkger"
+	"github.com/pkg/errors"
+)
+
+// PkgerMigrator is a migrator for SQL and Fizz
+// files packaged by markbates/pkger
+type PkgerMigrator struct {
+	Migrator
+	Path string
+}
+
+// NewPkgerMigrator for a path and a Connection
+func NewPkgerMigrator(path string, c *Connection) (PkgerMigrator, error) {
+	fm := PkgerMigrator{
+		Migrator: NewMigrator(c),
+		Path:     path,
+	}
+	fm.SchemaPath = path
+
+	runner := func(mf Migration, tx *Connection) error {
+		f, err := pkger.Open(mf.Path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		content, err := MigrationContent(mf, tx, f, true)
+		if err != nil {
+			return errors.Wrapf(err, "error processing %s", mf.Path)
+		}
+		if content == "" {
+			return nil
+		}
+		err = tx.RawQuery(content).Exec()
+		if err != nil {
+			return errors.Wrapf(err, "error executing %s, sql: %s", mf.Path, content)
+		}
+		return nil
+	}
+
+	err := fm.findMigrations(runner)
+	if err != nil {
+		return fm, err
+	}
+
+	return fm, nil
+}
+
+func (fm *PkgerMigrator) findMigrations(runner func(mf Migration, tx *Connection) error) error {
+	dir := fm.Path
+	if fi, err := pkger.Stat(dir); err != nil || !fi.IsDir() {
+		// directory doesn't exist
+		return nil
+	}
+	return pkger.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		//	fmt.Printf("walking %v: %v", p, info)
+		if !info.IsDir() {
+			match, err := ParseMigrationFilename(info.Name())
+			//		fmt.Printf("match: %v, err: %v", match, err)
+			if err != nil {
+				return err
+			}
+			if match == nil {
+				return nil
+			}
+			mf := Migration{
+				Path:      p,
+				Version:   match.Version,
+				Name:      match.Name,
+				DBType:    match.DBType,
+				Direction: match.Direction,
+				Type:      match.Type,
+				Runner:    runner,
+			}
+			fm.Migrations[mf.Direction] = append(fm.Migrations[mf.Direction], mf)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
I copy-pasted the FileMigrator to use pkger.Open and pkger.Stat instead of os.Open and os.Stat.
It work for my use case: embedding the migration files inside my binary that I deploy on Android
thanks to [Gio](https://gioui.org).