### PR TITLE
Align SQLite CreateDB behavior on other drivers

### DIFF
--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -133,17 +133,21 @@ func (m *sqlite) locker(l *sync.Mutex, fn func() error) error {
 }
 
 func (m *sqlite) CreateDB() error {
-	d := filepath.Dir(m.ConnectionDetails.Database)
-	err := os.MkdirAll(d, 0766)
+	_, err := os.Stat(m.ConnectionDetails.Database)
+	if err == nil {
+		return errors.Errorf("could not create SQLite database '%s'; database exists", m.ConnectionDetails.Database)
+	}
+	dir := filepath.Dir(m.ConnectionDetails.Database)
+	err = os.MkdirAll(dir, 0766)
 	if err != nil {
-		return errors.Wrapf(err, "could not create SQLite database %s", m.ConnectionDetails.Database)
+		return errors.Wrapf(err, "could not create SQLite database '%s'", m.ConnectionDetails.Database)
 	}
 	_, err = os.Create(m.ConnectionDetails.Database)
 	if err != nil {
-		return errors.Wrapf(err, "could not create SQLite database %s", m.ConnectionDetails.Database)
+		return errors.Wrapf(err, "could not create SQLite database '%s'", m.ConnectionDetails.Database)
 	}
 
-	log(logging.Info, "created database %s", m.ConnectionDetails.Database)
+	log(logging.Info, "created database '%s'", m.ConnectionDetails.Database)
 	return nil
 }
 
@@ -152,7 +156,7 @@ func (m *sqlite) DropDB() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not drop SQLite database %s", m.ConnectionDetails.Database)
 	}
-	log(logging.Info, "dropped database %s", m.ConnectionDetails.Database)
+	log(logging.Info, "dropped database '%s'", m.ConnectionDetails.Database)
 	return nil
 }
 

--- a/dialect_sqlite_test.go
+++ b/dialect_sqlite_test.go
@@ -3,6 +3,7 @@
 package pop
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -143,4 +144,22 @@ func Test_ConnectionDetails_FinalizeOSPath(t *testing.T) {
 	r.NoError(cd.Finalize())
 	r.Equal("sqlite3", cd.Dialect)
 	r.EqualValues(p, cd.Database)
+}
+
+func TestSqlite_CreateDB(t *testing.T) {
+	r := require.New(t)
+	dir, err := ioutil.TempDir("", "")
+	r.NoError(err)
+	p := filepath.Join(dir, "testdb.sqlite")
+	defer os.RemoveAll(p)
+	cd := &ConnectionDetails{
+		Dialect:  "sqlite",
+		Database: p,
+	}
+	dialect, err := newSQLite(cd)
+	r.NoError(err)
+	r.NoError(dialect.CreateDB())
+
+	// Creating DB twice should produce an error
+	r.EqualError(dialect.CreateDB(), fmt.Sprintf("could not create SQLite database '%s'; database exists", p))
 }


### PR DESCRIPTION
Trying to create an existing SQLite DB will now produce an error.

Fixes #501.