### PR TITLE
removed `inRegex` matching non-replaced strings

### DIFF
--- a/sql_builder.go
+++ b/sql_builder.go
@@ -70,7 +70,7 @@ func (sq *sqlBuilder) Args() []interface{} {
 	return sq.args
 }
 
-var inRegex = regexp.MustCompile(`(?i)in\s*\(\s*\?\s*\)`)
+var inRegex = regexp.MustCompile(`(?i)in\s*\(\?\)`)
 
 func (sq *sqlBuilder) compile() {
 	if sq.sql == "" {


### PR DESCRIPTION
currently inRegex will match `(?)`, `( ?)`, `(? )`, and `( ? )`. This
is a bug since the function `Where` in query.go has on line 138

`stmt = strings.Replace(stmt, "(?)", qs, 1)`

which only will replace the string `(?)`