### PR TITLE
removed simple+incorrect IN expansion

### DIFF
--- a/query.go
+++ b/query.go
@@ -1,9 +1,6 @@
 package pop
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/gobuffalo/pop/v5/logging"
 )
 
@@ -128,14 +125,6 @@ func (q *Query) Where(stmt string, args ...interface{}) *Query {
 	if q.RawSQL.Fragment != "" {
 		log(logging.Warn, "Query is setup to use raw SQL")
 		return q
-	}
-	if inRegex.MatchString(stmt) {
-		var inq []string
-		for i := 0; i < len(args); i++ {
-			inq = append(inq, "?")
-		}
-		qs := fmt.Sprintf("(%s)", strings.Join(inq, ","))
-		stmt = strings.Replace(stmt, "(?)", qs, 1)
 	}
 	q.whereClauses = append(q.whereClauses, clause{stmt, args})
 	return q

--- a/query_test.go
+++ b/query_test.go
@@ -49,7 +49,7 @@ func Test_Where_In(t *testing.T) {
 		r.NoError(err)
 
 		var songs []Song
-		err = tx.Where("id in (?)", u1.ID, u3.ID).All(&songs)
+		err = tx.Where("id in (?)", []interface{}{u1.ID, u3.ID}).All(&songs)
 		r.NoError(err)
 		r.Len(songs, 2)
 	})
@@ -95,7 +95,7 @@ func Test_Where_In_Complex(t *testing.T) {
 		r.NoError(err)
 
 		var songs []Song
-		err = tx.Where("id in (?)", u1.ID, u3.ID).Where("title = ?", "A").All(&songs)
+		err = tx.Where("id in (?)", []interface{}{u1.ID, u3.ID}).Where("title = ?", "A").All(&songs)
 		r.NoError(err)
 		r.Len(songs, 2)
 	})


### PR DESCRIPTION
in `sql_builder.go` line 91 already calls out to `sqlx.In` to do an
expansion that supports multiple IN statements. The removed section
duplicated behavior and has a bug between the regex selection and what
`strings.Replace` replaces (selects `\(\s*\?\s*\)` but only replaces
`\(\?\)`