### PR TITLE
feat: make CreateSchemaMigrations independent of the migrator

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -171,8 +171,7 @@ func (m Migrator) Reset() error {
 
 // CreateSchemaMigrations sets up a table to track migrations. This is an idempotent
 // operation.
-func (m Migrator) CreateSchemaMigrations() error {
-	c := m.Connection
+func CreateSchemaMigrations(c *Connection) error {
 	mtn := c.MigrationTableName()
 	err := c.Open()
 	if err != nil {
@@ -195,6 +194,12 @@ func (m Migrator) CreateSchemaMigrations() error {
 		}
 		return nil
 	})
+}
+
+// CreateSchemaMigrations sets up a table to track migrations. This is an idempotent
+// operation.
+func (m Migrator) CreateSchemaMigrations() error {
+	return CreateSchemaMigrations(m.Connection)
 }
 
 // Status prints out the status of applied/pending migrations.


### PR DESCRIPTION
`CreateSchemaMigrations` is not dependent on the migrator so it can easily be exposed as `pop.CreateSchemaMigrations`.
For backwards compatibility there is still the receiver version of the function.
The concrete use case was that I am moving from a different migration system and therefore I have to translate all the migration tables. This PR provides a safe way to create the pop migrations table.
I can also document this change but that would have to be in a different repo right?