### PR TITLE
fix: make dialect.URL() return the url with the scheme consistently

### DIFF
--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -159,13 +159,13 @@ func (p *cockroach) URL() string {
 	if c.URL != "" {
 		return c.URL
 	}
-	s := "postgres://%s:%s@%s:%s/%s?%s"
+	s := "cockroach://%s:%s@%s:%s/%s?%s"
 	return fmt.Sprintf(s, c.User, c.Password, c.Host, c.Port, c.Database, c.OptionsString(""))
 }
 
 func (p *cockroach) urlWithoutDb() string {
 	c := p.ConnectionDetails
-	s := "postgres://%s:%s@%s:%s/?%s"
+	s := "cockroach://%s:%s@%s:%s/?%s"
 	return fmt.Sprintf(s, c.User, c.Password, c.Host, c.Port, c.OptionsString(""))
 }
 
@@ -265,9 +265,9 @@ func finalizerCockroach(cd *ConnectionDetails) {
 	appName := filepath.Base(os.Args[0])
 	cd.Options["application_name"] = defaults.String(cd.Options["application_name"], appName)
 	cd.Port = defaults.String(cd.Port, portCockroach)
-	if cd.URL != "" {
-		cd.URL = "postgres://" + trimCockroachPrefix(cd.URL)
-	}
+	//if cd.URL != "" {
+	//	cd.URL = "postgres://" + trimCockroachPrefix(cd.URL)
+	//}
 }
 
 func trimCockroachPrefix(u string) string {

--- a/dialect_cockroach_test.go
+++ b/dialect_cockroach_test.go
@@ -16,8 +16,8 @@ func Test_Cockroach_URL_Raw(t *testing.T) {
 	err := cd.Finalize()
 	r.NoError(err)
 	m := &cockroach{commonDialect: commonDialect{ConnectionDetails: cd}}
-	r.Equal("postgres://user:pass@host:1234/database?option1=value1", m.URL())
-	r.Equal("postgres://user:pass@host:1234/?option1=value1", m.urlWithoutDb())
+	r.Equal("cockroach://user:pass@host:1234/database?option1=value1", m.URL())
+	r.Equal("cockroach://user:pass@host:1234/?option1=value1", m.urlWithoutDb())
 }
 
 func Test_Cockroach_URL_Build(t *testing.T) {
@@ -37,13 +37,13 @@ func Test_Cockroach_URL_Build(t *testing.T) {
 	err := cd.Finalize()
 	r.NoError(err)
 	m := &cockroach{commonDialect: commonDialect{ConnectionDetails: cd}}
-	r.True(strings.HasPrefix(m.URL(), "postgres://user:pass@host:port/database?"), "URL() returns %v", m.URL())
+	r.True(strings.HasPrefix(m.URL(), "cockroach://user:pass@host:port/database?"), "URL() returns %v", m.URL())
 	r.Contains(m.URL(), "option1=value1")
 	r.Contains(m.URL(), "application_name=pop.test")
-	r.True(strings.HasPrefix(m.urlWithoutDb(), "postgres://user:pass@host:port/?"), "urlWithoutDb() returns %v", m.urlWithoutDb())
+	r.True(strings.HasPrefix(m.urlWithoutDb(), "cockroach://user:pass@host:port/?"), "urlWithoutDb() returns %v", m.urlWithoutDb())
 	r.Contains(m.urlWithoutDb(), "option1=value1")
 	r.Contains(m.urlWithoutDb(), "application_name=pop.test")
-	r.True(strings.HasPrefix(m.MigrationURL(), "postgres://user:pass@host:port/database?"), "MigrationURL() returns %v", m.MigrationURL())
+	r.True(strings.HasPrefix(m.MigrationURL(), "cockroach://user:pass@host:port/database?"), "MigrationURL() returns %v", m.MigrationURL())
 }
 
 func Test_Cockroach_URL_UserDefinedAppName(t *testing.T) {
@@ -94,6 +94,6 @@ func Test_Cockroach_URL_Only(t *testing.T) {
 	err := cd.Finalize()
 	r.NoError(err)
 	m := &cockroach{commonDialect: commonDialect{ConnectionDetails: cd}}
-	r.Equal("postgres://user:pass@host:1337/database?option1=value1", m.URL())
-	r.Equal("postgres://user:pass@host:1337/?option1=value1", m.urlWithoutDb())
+	r.Equal("cockroach://user:pass@host:1337/database?option1=value1", m.URL())
+	r.Equal("cockroach://user:pass@host:1337/?option1=value1", m.urlWithoutDb())
 }

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -54,7 +54,7 @@ func (m *mysql) Details() *ConnectionDetails {
 func (m *mysql) URL() string {
 	cd := m.ConnectionDetails
 	if cd.URL != "" {
-		return strings.TrimPrefix(cd.URL, "mysql://")
+		return cd.URL
 	}
 
 	user := fmt.Sprintf("%s:%s@", cd.User, cd.Password)
@@ -70,7 +70,7 @@ func (m *mysql) URL() string {
 		addr = fmt.Sprintf("unix(%s)", cd.Host)
 	}
 
-	s := "%s%s/%s?%s"
+	s := "mysql://%s%s/%s?%s"
 	return fmt.Sprintf(s, user, addr, cd.Database, cd.OptionsString(""))
 }
 

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -21,9 +21,9 @@ func Test_MySQL_URL_As_Is(t *testing.T) {
 	r.NoError(err)
 
 	m := &mysql{commonDialect{ConnectionDetails: cd}}
-	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
-	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
-	r.Equal("user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
+	r.Equal("mysql://user:pass@(host:port)/dbase?opt=value", m.URL())
+	r.Equal("mysql://user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+	r.Equal("mysql://user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
 }
 
 func Test_MySQL_URL_Override_withURL(t *testing.T) {
@@ -41,9 +41,9 @@ func Test_MySQL_URL_Override_withURL(t *testing.T) {
 	r.NoError(err)
 
 	m := &mysql{commonDialect{ConnectionDetails: cd}}
-	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
-	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
-	r.Equal("user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
+	r.Equal("mysql://user:pass@(host:port)/dbase?opt=value", m.URL())
+	r.Equal("mysql://user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+	r.Equal("mysql://user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
 }
 
 func Test_MySQL_URL_With_Values(t *testing.T) {
@@ -56,9 +56,9 @@ func Test_MySQL_URL_With_Values(t *testing.T) {
 		Password: "pass",
 		Options:  map[string]string{"opt": "value"},
 	}}}
-	r.Equal("user:pass@(host:port)/dbase?opt=value", m.URL())
-	r.Equal("user:pass@(host:port)/?opt=value", m.urlWithoutDb())
-	r.Equal("user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
+	r.Equal("mysql://user:pass@(host:port)/dbase?opt=value", m.URL())
+	r.Equal("mysql://user:pass@(host:port)/?opt=value", m.urlWithoutDb())
+	r.Equal("mysql://user:pass@(host:port)/dbase?opt=value", m.MigrationURL())
 }
 
 func Test_MySQL_URL_Without_User(t *testing.T) {
@@ -69,7 +69,7 @@ func Test_MySQL_URL_Without_User(t *testing.T) {
 	}}}
 	// finalizerMySQL fills address part in real world.
 	// without user, password cannot live alone
-	r.Equal("(:)/dbase?", m.URL())
+	r.Equal("mysql://(:)/dbase?", m.URL())
 }
 
 func Test_MySQL_URL_Without_Password(t *testing.T) {
@@ -79,7 +79,7 @@ func Test_MySQL_URL_Without_Password(t *testing.T) {
 		Database: "dbase",
 	}}}
 	// finalizerMySQL fills address part in real world.
-	r.Equal("user@(:)/dbase?", m.URL())
+	r.Equal("mysql://user@(:)/dbase?", m.URL())
 }
 
 func Test_MySQL_URL_urlParserMySQL_Standard(t *testing.T) {
@@ -116,7 +116,7 @@ func Test_MySQL_URL_urlParserMySQL_With_Protocol(t *testing.T) {
 func Test_MySQL_URL_urlParserMySQL_Socket(t *testing.T) {
 	r := require.New(t)
 	cd := &ConnectionDetails{
-		URL: "unix(/tmp/socket)/dbase",
+		URL: "mysql://unix(/tmp/socket)/dbase",
 	}
 	err := urlParserMySQL(cd)
 	r.NoError(err)
@@ -126,8 +126,8 @@ func Test_MySQL_URL_urlParserMySQL_Socket(t *testing.T) {
 	// additional test without URL
 	cd.URL = ""
 	m := &mysql{commonDialect{ConnectionDetails: cd}}
-	r.True(strings.HasPrefix(m.URL(), "unix(/tmp/socket)/dbase?"))
-	r.True(strings.HasPrefix(m.urlWithoutDb(), "unix(/tmp/socket)/?"))
+	r.True(strings.HasPrefix(m.URL(), "mysql://unix(/tmp/socket)/dbase?"))
+	r.True(strings.HasPrefix(m.urlWithoutDb(), "mysql://unix(/tmp/socket)/?"))
 }
 
 func Test_MySQL_URL_urlParserMySQL_Unsupported(t *testing.T) {

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -55,11 +55,13 @@ func (m *sqlite) Details() *ConnectionDetails {
 
 func (m *sqlite) URL() string {
 	c := m.ConnectionDetails
-	return c.Database + "?" + c.OptionsString("")
+	return strings.TrimSuffix(
+		fmt.Sprintf("sqlite3://%s?%s", c.Database, c.OptionsString("")),
+		"?")
 }
 
 func (m *sqlite) MigrationURL() string {
-	return m.ConnectionDetails.URL
+	return m.URL()
 }
 
 func (m *sqlite) Create(s store, model *Model, cols columns.Columns) error {

--- a/dialect_sqlite_test.go
+++ b/dialect_sqlite_test.go
@@ -163,3 +163,46 @@ func TestSqlite_CreateDB(t *testing.T) {
 	// Creating DB twice should produce an error
 	r.EqualError(dialect.CreateDB(), fmt.Sprintf("could not create SQLite database '%s'; database exists", p))
 }
+
+func TestSqlite_URL(t *testing.T) {
+	t.Run("case=url from database without options", func(t *testing.T) {
+		cd := &ConnectionDetails{
+			Dialect:  "sqlite",
+			Database: "/tmp/foo.db",
+		}
+		dialect, err := newSQLite(cd)
+		require.NoError(t, err)
+		require.Equal(t, "sqlite3:///tmp/foo.db", dialect.URL())
+	})
+
+	t.Run("case=url from database with options", func(t *testing.T) {
+		cd := &ConnectionDetails{
+			Dialect:  "sqlite",
+			Database: "/tmp/foo.db",
+			Options:  map[string]string{"_fk": "true"},
+		}
+		dialect, err := newSQLite(cd)
+		require.NoError(t, err)
+		require.Equal(t, "sqlite3:///tmp/foo.db?_fk=true", dialect.URL())
+	})
+
+	t.Run("case=url from url without options", func(t *testing.T) {
+		cd := &ConnectionDetails{
+			URL: "sqlite3:///tmp/foo.db",
+		}
+		require.NoError(t, urlParserSQLite3(cd))
+		dialect, err := newSQLite(cd)
+		require.NoError(t, err)
+		require.Equal(t, "sqlite3:///tmp/foo.db", dialect.URL())
+	})
+
+	t.Run("case=url from url with options", func(t *testing.T) {
+		cd := &ConnectionDetails{
+			URL: "sqlite3:///tmp/foo.db?_fk=true",
+		}
+		require.NoError(t, urlParserSQLite3(cd))
+		dialect, err := newSQLite(cd)
+		require.NoError(t, err)
+		require.Equal(t, "sqlite3:///tmp/foo.db?_fk=true", dialect.URL())
+	})
+}


### PR DESCRIPTION
This makes `connection.URL()` return the URL consistently.
closes #538

Before the mysql and sqlite dialects returned no scheme at all and cockroach returned the scheme `postgres`.