### PR TITLE
Return error when migration version does not exist

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -151,8 +151,11 @@ func (m Migrator) Down(step int) error {
 		}
 		for _, mi := range mfs {
 			exists, err := c.Where("version = ?", mi.Version).Exists(mtn)
-			if err != nil || !exists {
+			if err != nil {
 				return errors.Wrapf(err, "problem checking for migration version %s", mi.Version)
+			}
+			if !exists {
+				return errors.Errorf("migration version %s does not exist", mi.Version)
 			}
 			err = c.Transaction(func(tx *Connection) error {
 				err := mi.Run(tx)


### PR DESCRIPTION
Because `errors.Wrapf()` returns nil when `err` is nil, `!exist` would return nil despite it being an error state. This patch fixes addresses the issue by returning an error explicitly.