### PR TITLE
Only run compatible down migrations

### DIFF
--- a/migration_info.go
+++ b/migration_info.go
@@ -47,3 +47,13 @@ func (mfs Migrations) Less(i, j int) bool {
 func (mfs Migrations) Swap(i, j int) {
 	mfs[i], mfs[j] = mfs[j], mfs[i]
 }
+
+func (mfs *Migrations) Filter(f func(mf Migration) bool) {
+	vsf := make(Migrations, 0)
+	for _, v := range *mfs {
+		if f(v) {
+			vsf = append(vsf, v)
+		}
+	}
+	*mfs = vsf
+}

--- a/migrator.go
+++ b/migrator.go
@@ -90,11 +90,11 @@ func (m Migrator) UpTo(step int) (applied int, err error) {
 	err = m.exec(func() error {
 		mtn := c.MigrationTableName()
 		mfs := m.Migrations["up"]
+		mfs.Filter(func(mf Migration) bool {
+			return m.migrationIsCompatible(c.Dialect, mf)
+		})
 		sort.Sort(mfs)
 		for _, mi := range mfs {
-			if !m.migrationIsCompatible(c.Dialect, mi) {
-				continue
-			}
 			exists, err := c.Where("version = ?", mi.Version).Exists(mtn)
 			if err != nil {
 				return errors.Wrapf(err, "problem checking for migration version %s", mi.Version)
@@ -140,6 +140,9 @@ func (m Migrator) Down(step int) error {
 			return errors.Wrap(err, "migration down: unable count existing migration")
 		}
 		mfs := m.Migrations["down"]
+		mfs.Filter(func(mf Migration) bool {
+			return m.migrationIsCompatible(c.Dialect, mf)
+		})
 		sort.Sort(sort.Reverse(mfs))
 		// skip all ran migration
 		if len(mfs) > count {

--- a/packrd/packed-packr.go
+++ b/packrd/packed-packr.go
@@ -31,8 +31,7 @@ var _ = func() error {
 		b := packr.New("github.com/gobuffalo/pop/v5/genny/model/templates", "../model/templates")
 		b.SetResolver("-path-/-name-.go.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "fd34d2cca184d1b4064adfc3bbcec4c6"})
 		b.SetResolver("-path-/-name-_test.go.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "f0365201a1fff056862862ae1fe97c7a"})
-		}()
-
+	}()
 
 	func() {
 		b := packr.New("pop:genny:config", "../config/templates")
@@ -41,7 +40,7 @@ var _ = func() error {
 		b.SetResolver("mysql.yml.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "61f8f853a1eb5098e29f68f19098fa64"})
 		b.SetResolver("postgres.yml.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "3abfce8456ed838a8a49ed01c478f6c3"})
 		b.SetResolver("sqlite3.yml.tmpl", packr.Pointer{ForwardBox: gk, ForwardPath: "657982e88b05d0a50529d69f20b7ede0"})
-		}()
+	}()
 
 	return nil
 }()


### PR DESCRIPTION
Previously `Migrator.Down()` would run incompatible migrations. This patch addresses that issue by checking if the migration is compatible with the current translator/database before applying it.