### PR TITLE
fix: return error when ID field is missing

### DIFF
--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -68,7 +68,10 @@ func (p *cockroach) Details() *ConnectionDetails {
 }
 
 func (p *cockroach) Create(s store, model *Model, cols columns.Columns) error {
-	keyType := model.PrimaryKeyType()
+	keyType, err := model.PrimaryKeyType()
+	if err != nil {
+		return err
+	}
 	switch keyType {
 	case "int", "int64":
 		cols.Remove("id")

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -44,7 +44,10 @@ func (commonDialect) Quote(key string) string {
 }
 
 func genericCreate(s store, model *Model, cols columns.Columns, quoter quotable) error {
-	keyType := model.PrimaryKeyType()
+	keyType, err := model.PrimaryKeyType()
+	if err != nil {
+		return err
+	}
 	switch keyType {
 	case "int", "int64":
 		var id int64

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -55,7 +55,10 @@ func (p *postgresql) Details() *ConnectionDetails {
 }
 
 func (p *postgresql) Create(s store, model *Model, cols columns.Columns) error {
-	keyType := model.PrimaryKeyType()
+	keyType, err := model.PrimaryKeyType()
+	if err != nil {
+		return err
+	}
 	switch keyType {
 	case "int", "int64":
 		cols.Remove("id")

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -64,7 +64,10 @@ func (m *sqlite) MigrationURL() string {
 
 func (m *sqlite) Create(s store, model *Model, cols columns.Columns) error {
 	return m.locker(m.smGil, func() error {
-		keyType := model.PrimaryKeyType()
+		keyType, err := model.PrimaryKeyType()
+		if err != nil {
+			return err
+		}
 		switch keyType {
 		case "int", "int64":
 			var id int64

--- a/finders.go
+++ b/finders.go
@@ -38,13 +38,16 @@ func (q *Query) Find(model interface{}, id interface{}) error {
 		// Pick argument type based on column type. This is required for keeping backwards compatibility with:
 		//
 		// https://github.com/gobuffalo/buffalo/blob/master/genny/resource/templates/use_model/actions/resource-name.go.tmpl#L76
-		switch m.ID().(type) {
-		case int32, int64, uint32, uint64, int8, uint8, int16, uint16, int:
+		pkt, err := m.PrimaryKeyType()
+		if err != nil {
+			return err
+		}
+
+		switch pkt {
+		case "int32", "int64", "uint32", "uint64", "int8", "uint8", "int16", "uint16", "int":
 			if tid, ok := id.(string); ok {
-				var err error
-				id, err = strconv.Atoi(tid)
-				if err == nil {
-					return q.Where(idq, id).First(model)
+				if intID, err := strconv.Atoi(tid); err == nil {
+					return q.Where(idq, intID).First(model)
 				}
 			}
 		}
@@ -144,7 +147,7 @@ func (q *Query) All(models interface{}) error {
 	})
 
 	if err != nil {
-		return errors.Wrap(err, "unable to fetch records")
+		return err //errors.Wrap(err, "unable to fetch records")
 	}
 
 	if q.eager {
@@ -291,7 +294,7 @@ func (q *Query) eagerDefaultAssociations(model interface{}) error {
 // 	q.Where("name = ?", "mark").Exists(&User{})
 func (q *Query) Exists(model interface{}) (bool, error) {
 	tmpQuery := Q(q.Connection)
-	q.Clone(tmpQuery) //avoid meddling with original query
+	q.Clone(tmpQuery) // avoid meddling with original query
 
 	var res bool
 
@@ -337,7 +340,7 @@ func (q Query) Count(model interface{}) (int, error) {
 //	q.Where("sex = ?", "f").Count(&User{}, "name")
 func (q Query) CountByField(model interface{}, field string) (int, error) {
 	tmpQuery := Q(q.Connection)
-	q.Clone(tmpQuery) //avoid meddling with original query
+	q.Clone(tmpQuery) // avoid meddling with original query
 
 	res := &rowCount{}
 
@@ -346,7 +349,7 @@ func (q Query) CountByField(model interface{}, field string) (int, error) {
 		tmpQuery.orderClauses = clauses{}
 		tmpQuery.limitResults = 0
 		query, args := tmpQuery.ToSQL(&Model{Value: model})
-		//when query contains custom selected fields / executed using RawQuery,
+		// when query contains custom selected fields / executed using RawQuery,
 		//	sql may already contains limit and offset
 
 		if rLimitOffset.MatchString(query) {

--- a/model.go
+++ b/model.go
@@ -2,6 +2,7 @@ package pop
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"reflect"
 	"sync"
 	"time"
@@ -34,9 +35,9 @@ type Model struct {
 func (m *Model) ID() interface{} {
 	fbn, err := m.fieldByName("ID")
 	if err != nil {
-		return 0
+		return nil
 	}
-	if m.PrimaryKeyType() == "UUID" {
+	if pkt, _ := m.PrimaryKeyType(); pkt == "UUID" {
 		return fbn.Interface().(uuid.UUID).String()
 	}
 	return fbn.Interface()
@@ -57,12 +58,12 @@ func (m *Model) IDField() string {
 }
 
 // PrimaryKeyType gives the primary key type of the `Model`.
-func (m *Model) PrimaryKeyType() string {
+func (m *Model) PrimaryKeyType() (string, error) {
 	fbn, err := m.fieldByName("ID")
 	if err != nil {
-		return "int"
+		return "", errors.Errorf("model %T is missing required field ID", m.Value)
 	}
-	return fbn.Type().Name()
+	return fbn.Type().Name(), nil
 }
 
 // TableNameAble interface allows for the customize table mapping

--- a/pop_test.go
+++ b/pop_test.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/gobuffalo/nulls"
-	"github.com/gobuffalo/pop/v5/logging"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/gobuffalo/pop/v5/logging"
 )
 
 var PDB *Connection
@@ -71,6 +72,14 @@ func transaction(fn func(tx *Connection)) {
 
 func ts(s string) string {
 	return PDB.Dialect.TranslateSQL(s)
+}
+
+type Client struct {
+	ClientID string `db:"id"`
+}
+
+func (c Client) TableName() string {
+	return "clients"
 }
 
 type User struct {

--- a/test.sh
+++ b/test.sh
@@ -38,7 +38,7 @@ function cleanup {
 trap cleanup EXIT
 
 docker-compose up -d
-sleep 4 # Ensure mysql is online
+sleep 5 # Ensure mysql is online
 
 go build -v -tags sqlite -o tsoda ./soda
 

--- a/testdata/migrations/20200621140800_clients.down.fizz
+++ b/testdata/migrations/20200621140800_clients.down.fizz
@@ -1,0 +1,1 @@
+drop_table("clients")

--- a/testdata/migrations/20200621140800_clients.up.fizz
+++ b/testdata/migrations/20200621140800_clients.up.fizz
@@ -1,0 +1,4 @@
+create_table("clients") {
+ t.Column("id", "string", {"length": 32, "primary": true})
+ t.DisableTimestamps()
+}


### PR DESCRIPTION
Instead of optimistically guessing that the ID of a model is an int when the ID field is not defined, this patch now explicitly returns an error. This resolves several edgecase scenarios and closes #565