### PR TITLE
Stop obfuscating transaction error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -146,10 +146,12 @@ func (c *Connection) Transaction(fn func(tx *Connection) error) error {
 		} else {
 			dberr = cn.TX.Commit()
 		}
-		if err != nil {
-			return err
+
+		if dberr != nil {
+			return errors.Wrap(dberr, "error committing or rolling back transaction")
 		}
-		return errors.Wrap(dberr, "error committing or rolling back transaction")
+
+		return err
 	})
 
 }


### PR DESCRIPTION
Previously, errors happening in `Commit` or `Rollback` would always be overwritten by the inner error. For certain drivers this would obfuscate the reason for the error and return a generic: "current transaction is aborted, commands ignored until end of transaction block".

This patch fixes the flawed error handling logic and properly returns the error's root cause (e.g. FK violation).