### PR TITLE
Return original error when closing prepared statement

### DIFF
--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -89,8 +89,8 @@ func (p *cockroach) Create(s store, model *Model, cols columns.Columns) error {
 		}
 		err = stmt.Get(&id, model.Value)
 		if err != nil {
-			if err := stmt.Close(); err != nil {
-				return errors.WithMessage(err, "failed to close statement")
+			if closeErr := stmt.Close(); closeErr != nil {
+				return errors.Wrapf(err, "failed to close prepared statement: %s", closeErr)
 			}
 			return err
 		}

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -85,8 +85,8 @@ func genericCreate(s store, model *Model, cols columns.Columns, quoter quotable)
 		}
 		_, err = stmt.Exec(model.Value)
 		if err != nil {
-			if err := stmt.Close(); err != nil {
-				return errors.WithMessage(err, "failed to close statement")
+			if closeErr := stmt.Close(); closeErr != nil {
+				return errors.Wrapf(err, "failed to close prepared statement: %s", closeErr)
 			}
 			return err
 		}

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -76,8 +76,8 @@ func (p *postgresql) Create(s store, model *Model, cols columns.Columns) error {
 		}
 		err = stmt.Get(&id, model.Value)
 		if err != nil {
-			if err := stmt.Close(); err != nil {
-				return errors.WithMessage(err, "failed to close statement")
+			if closeErr := stmt.Close(); closeErr != nil {
+				return errors.Wrapf(err, "failed to close prepared statement: %s", closeErr)
 			}
 			return err
 		}


### PR DESCRIPTION
Previously, errors happening in prepared statements would be overshadowed by the statement close error. The `database/sql` documentation actually recommends using `statement.Close()` without error checking: https://golang.org/pkg/database/sql/#example_DB_Prepare

This patch addresses the issue which would cause the generic error message "current transaction is aborted, commands ignored until end of transaction block" when using prepared statements by properly wrapping errors.