### PR TITLE
Add support for embedded structs

### DIFF
--- a/columns/columns_for_struct.go
+++ b/columns/columns_for_struct.go
@@ -45,7 +45,7 @@ func appendStruct(columns Columns, st reflect.Type) {
 		popTags := TagsFor(field)
 		tag := popTags.Find("db")
 
-		if tag.Attrs["inline"] {
+		if tag.Options["inline"] {
 			appendStruct(columns, field.Type)
 		}
 		if !tag.Ignored() && !tag.Empty() {

--- a/columns/columns_for_struct.go
+++ b/columns/columns_for_struct.go
@@ -2,6 +2,8 @@ package columns
 
 import (
 	"reflect"
+
+	"github.com/jmoiron/sqlx/reflectx"
 )
 
 // ForStruct returns a Columns instance for
@@ -31,12 +33,10 @@ func ForStructWithAlias(s interface{}, tableName string, tableAlias string) (col
 		}
 	}
 
-	fieldCount := st.NumField()
+	fieldMap := reflectx.NewMapper("").TypeMap(st)
 
-	for i := 0; i < fieldCount; i++ {
-		field := st.Field(i)
-
-		popTags := TagsFor(field)
+	for _, i := range fieldMap.Index {
+		popTags := TagsFor(i.Field)
 		tag := popTags.Find("db")
 
 		if !tag.Ignored() && !tag.Empty() {

--- a/columns/columns_test.go
+++ b/columns/columns_test.go
@@ -16,6 +16,11 @@ type foo struct {
 	WriteOnly string `db:"write" rw:"w"`
 }
 
+type bar struct {
+	foo
+	MiddleName string `db:"middle_name"`
+}
+
 type foos []foo
 
 func Test_Column_MapsSlice(t *testing.T) {
@@ -80,4 +85,17 @@ func Test_Columns_Sorted(t *testing.T) {
 	r.Equal(c.SymbolizedString(), ":amount, :amount_units")
 	r.Equal(c.String(), "amount, amount_units")
 	r.Equal(c.QuotedString(fooQuoter{}), "`amount`, `amount_units`")
+}
+
+func Test_Columns_Embedded(t *testing.T) {
+	r := require.New(t)
+
+	c := columns.ForStruct(bar{}, "bar")
+
+	r.Equal(c.Cols["first_name"], &columns.Column{Name: "first_name", Writeable: false, Readable: true, SelectSQL: "first_name as f"})
+	r.Equal(c.Cols["middle_name"], &columns.Column{Name: "middle_name", Writeable: true, Readable: true, SelectSQL: "bar.middle_name"})
+	r.Equal(c.Cols["LastName"], &columns.Column{Name: "LastName", Writeable: true, Readable: true, SelectSQL: "bar.LastName"})
+	r.Equal(c.Cols["read"], &columns.Column{Name: "read", Writeable: false, Readable: true, SelectSQL: "bar.read"})
+	r.Equal(c.Cols["write"], &columns.Column{Name: "write", Writeable: true, Readable: false, SelectSQL: "bar.write"})
+	r.Equal(c.Cols["foo"], &columns.Column{Name: "foo", Writeable: true, Readable: true, SelectSQL: "bar.foo"})
 }

--- a/columns/tags.go
+++ b/columns/tags.go
@@ -9,9 +9,9 @@ var tags = "db rw select belongs_to has_many has_one fk_id primary_id order_by m
 
 // Tag represents a field tag defined exclusively for pop package.
 type Tag struct {
-	Value string
-	Name  string
-	Attrs map[string]bool
+	Value   string
+	Name    string
+	Options map[string]bool
 }
 
 // Empty validates if this pop tag is empty.

--- a/columns/tags.go
+++ b/columns/tags.go
@@ -11,6 +11,7 @@ var tags = "db rw select belongs_to has_many has_one fk_id primary_id order_by m
 type Tag struct {
 	Value string
 	Name  string
+	Attrs map[string]bool
 }
 
 // Empty validates if this pop tag is empty.
@@ -42,14 +43,19 @@ func (t Tags) Find(name string) Tag {
 // in model field.
 func TagsFor(field reflect.StructField) Tags {
 	pTags := Tags{}
+	attrs := map[string]bool{}
 	for _, tag := range strings.Fields(tags) {
 		if valTag := field.Tag.Get(tag); valTag != "" {
-			pTags = append(pTags, Tag{valTag, tag})
+			vals := strings.Split(valTag, ",")
+			for _, attr := range vals[1:] {
+				attrs[attr] = true
+			}
+			pTags = append(pTags, Tag{vals[0], tag, attrs})
 		}
 	}
 
 	if len(pTags) == 0 {
-		pTags = append(pTags, Tag{field.Name, "db"})
+		pTags = append(pTags, Tag{field.Name, "db", attrs})
 	}
 	return pTags
 }


### PR DESCRIPTION
Closes #351

Currently, pop treats embedded structs as a distinct field (like the reflection package exposes). sqlx, which binds the values out of the struct treats the embedded fields as if on the parent (like the language makes appear to happen). 

This checks for a newly introduced `inline` option to the `db` flag in the struct tags and inlines a struct (embedded or not), so that that struct's fields are included as if part of the parent object.

- `db:",inline"` or `db:"-,inline"` will inline the struct, but not include the field
- `db:"name,inline"`will include all of the fields on the struct, *and* the struct itself as the name field.
- `db:"name"`will include the struct as the name field. (Useful for struct types that implement `Valuer` and `Scanner`.)

This preserves the previous behavior by default, but allows embedded structs to be ignored as well.