### PR TITLE
feat: allow passing options to a new transaction

### DIFF
--- a/db.go
+++ b/db.go
@@ -2,6 +2,7 @@ package pop
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -11,11 +12,15 @@ type dB struct {
 }
 
 func (db *dB) TransactionContext(ctx context.Context) (*Tx, error) {
-	return newTX(ctx, db)
+	return newTX(ctx, db, nil)
 }
 
 func (db *dB) Transaction() (*Tx, error) {
-	return newTX(context.Background(), db)
+	return newTX(context.Background(), db, nil)
+}
+
+func (db *dB) TransactionContextOptions(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
+	return newTX(ctx, db, opts)
 }
 
 func (db *dB) Rollback() error {

--- a/store.go
+++ b/store.go
@@ -27,6 +27,7 @@ type store interface {
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareNamedContext(context.Context, string) (*sqlx.NamedStmt, error)
 	TransactionContext(context.Context) (*Tx, error)
+	TransactionContextOptions(context.Context, *sql.TxOptions) (*Tx, error)
 }
 
 // ContextStore wraps a store with a Context, so passes it with the functions that don't take it.

--- a/tx.go
+++ b/tx.go
@@ -2,6 +2,7 @@ package pop
 
 import (
 	"context"
+	"database/sql"
 	"math/rand"
 	"time"
 
@@ -19,11 +20,11 @@ type Tx struct {
 	*sqlx.Tx
 }
 
-func newTX(ctx context.Context, db *dB) (*Tx, error) {
+func newTX(ctx context.Context, db *dB, opts *sql.TxOptions) (*Tx, error) {
 	t := &Tx{
 		ID: rand.Int(),
 	}
-	tx, err := db.BeginTxx(ctx, nil)
+	tx, err := db.BeginTxx(ctx, opts)
 	t.Tx = tx
 	return t, errors.Wrap(err, "could not create new transaction")
 }
@@ -31,6 +32,12 @@ func newTX(ctx context.Context, db *dB) (*Tx, error) {
 // TransactionContext simply returns the current transaction,
 // this is defined so it implements the `Store` interface.
 func (tx *Tx) TransactionContext(ctx context.Context) (*Tx, error) {
+	return tx, nil
+}
+
+// TransactionContextOptions simply returns the current transaction,
+// this is defined so it implements the `Store` interface.
+func (tx *Tx) TransactionContextOptions(_ context.Context, _ *sql.TxOptions) (*Tx, error) {
 	return tx, nil
 }
 


### PR DESCRIPTION
This adds a new function that allows creating a transaction with `sql.TxOptions`.