### PR TITLE
Add support for pointer FKs when preloading a belongs_to association

### DIFF
--- a/pop_test.go
+++ b/pop_test.go
@@ -138,14 +138,16 @@ type Book struct {
 }
 
 type Taxi struct {
-	ID        int       `db:"id"`
-	Model     string    `db:"model"`
-	UserID    nulls.Int `db:"user_id"`
-	AddressID *int      `db:"address_id"`
-	Driver    *User     `belongs_to:"user" fk_id:"user_id"`
-	Address   Address   `belongs_to:"address"`
-	CreatedAt time.Time `db:"created_at"`
-	UpdatedAt time.Time `db:"updated_at"`
+	ID          int       `db:"id"`
+	Model       string    `db:"model"`
+	UserID      nulls.Int `db:"user_id"`
+	AddressID   nulls.Int `db:"address_id"`
+	Driver      *User     `belongs_to:"user" fk_id:"user_id"`
+	Address     Address   `belongs_to:"address"`
+	ToAddressID *int      `db:"to_address_id"`
+	ToAddress   *Address  `belongs_to:"address"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
 }
 
 // Validate gets run every time you call a "Validate*" (ValidateAndSave, ValidateAndCreate, ValidateAndUpdate) method.

--- a/pop_test.go
+++ b/pop_test.go
@@ -141,7 +141,7 @@ type Taxi struct {
 	ID        int       `db:"id"`
 	Model     string    `db:"model"`
 	UserID    nulls.Int `db:"user_id"`
-	AddressID nulls.Int `db:"address_id"`
+	AddressID *int      `db:"address_id"`
 	Driver    *User     `belongs_to:"user" fk_id:"user_id"`
 	Address   Address   `belongs_to:"address"`
 	CreatedAt time.Time `db:"created_at"`

--- a/preload_associations.go
+++ b/preload_associations.go
@@ -389,8 +389,9 @@ func preloadBelongsTo(tx *Connection, asoc *AssociationMetaInfo, mmi *ModelMetaI
 		modelAssociationField := mmi.mapper.FieldByName(mvalue, asoc.Name)
 		for i := 0; i < slice.Elem().Len(); i++ {
 			asocValue := slice.Elem().Index(i)
-			if mmi.mapper.FieldByName(mvalue, fi.Path).Interface() == mmi.mapper.FieldByName(asocValue, "ID").Interface() ||
-				reflect.DeepEqual(mmi.mapper.FieldByName(mvalue, fi.Path), mmi.mapper.FieldByName(asocValue, "ID")) {
+			fkField := reflect.Indirect(mmi.mapper.FieldByName(mvalue, fi.Path))
+			if fkField.Interface() == mmi.mapper.FieldByName(asocValue, "ID").Interface() ||
+				reflect.DeepEqual(fkField, mmi.mapper.FieldByName(asocValue, "ID")) {
 
 				switch {
 				case modelAssociationField.Kind() == reflect.Slice || modelAssociationField.Kind() == reflect.Array:

--- a/preload_associations_test.go
+++ b/preload_associations_test.go
@@ -216,7 +216,7 @@ func Test_New_Implementation_For_BelongsTo_Multiple_Fields(t *testing.T) {
 		address := Address{HouseNumber: 2, Street: "Street One"}
 		a.NoError(tx.Create(&address))
 
-		taxi := Taxi{UserID: nulls.NewInt(user.ID), AddressID: &address.ID}
+		taxi := Taxi{UserID: nulls.NewInt(user.ID), AddressID: nulls.NewInt(address.ID)}
 		a.NoError(tx.Create(&taxi))
 
 		book := Book{TaxiID: nulls.NewInt(taxi.ID), Title: "My Book"}
@@ -228,6 +228,39 @@ func Test_New_Implementation_For_BelongsTo_Multiple_Fields(t *testing.T) {
 		a.Len(books, 1)
 		a.Equal(user.Name.String, books[0].Taxi.Driver.Name.String)
 		a.Equal(address.Street, books[0].Taxi.Address.Street)
+		SetEagerMode(EagerDefault)
+	})
+}
+
+func Test_New_Implementation_For_BelongsTo_Ptr_Field(t *testing.T) {
+	if PDB == nil {
+		t.Skip("skipping integration tests")
+	}
+	transaction(func(tx *Connection) {
+		a := require.New(t)
+		toAddress := Address{HouseNumber: 1, Street: "Destination Ave"}
+		a.NoError(tx.Create(&toAddress))
+
+		taxi := Taxi{ToAddressID: &toAddress.ID}
+		a.NoError(tx.Create(&taxi))
+
+		book1 := Book{TaxiID: nulls.NewInt(taxi.ID), Title: "My Book"}
+		a.NoError(tx.Create(&book1))
+
+		taxiNilToAddress := Taxi{ToAddressID: nil}
+		a.NoError(tx.Create(&taxiNilToAddress))
+
+		book2 := Book{TaxiID: nulls.NewInt(taxiNilToAddress.ID), Title: "Another Book"}
+		a.NoError(tx.Create(&book2))
+
+		SetEagerMode(EagerPreload)
+		books := []Book{}
+		a.NoError(tx.EagerPreload("Taxi.ToAddress").Order("created_at").All(&books))
+		a.Len(books, 2)
+		a.Equal(toAddress.Street, books[0].Taxi.ToAddress.Street)
+		a.NotNil(books[0].Taxi.ToAddressID)
+		a.Nil(books[1].Taxi.ToAddress)
+		a.Nil(books[1].Taxi.ToAddressID)
 		SetEagerMode(EagerDefault)
 	})
 }

--- a/preload_associations_test.go
+++ b/preload_associations_test.go
@@ -216,7 +216,7 @@ func Test_New_Implementation_For_BelongsTo_Multiple_Fields(t *testing.T) {
 		address := Address{HouseNumber: 2, Street: "Street One"}
 		a.NoError(tx.Create(&address))
 
-		taxi := Taxi{UserID: nulls.NewInt(user.ID), AddressID: nulls.NewInt(address.ID)}
+		taxi := Taxi{UserID: nulls.NewInt(user.ID), AddressID: &address.ID}
 		a.NoError(tx.Create(&taxi))
 
 		book := Book{TaxiID: nulls.NewInt(taxi.ID), Title: "My Book"}

--- a/testdata/migrations/20181104135856_taxis.up.fizz
+++ b/testdata/migrations/20181104135856_taxis.up.fizz
@@ -2,6 +2,7 @@ create_table("taxis") {
   t.Column("id", "int", {primary: true})
   t.Column("model", "string", {})
   t.Column("user_id", "int", {"null": true})
-  t.Column("address_id", "int",{"null":true})
+  t.Column("address_id", "int", {"null":true})
+  t.Column("to_address_id", "int", {"null":true})
   t.Timestamps()
 }


### PR DESCRIPTION
This PR solves the first issue mentioned in #547 -- the associated model fails to load when doing a `EagerPreload` on a `belongs_to` association where the FK field is a pointer.  Using `Eager`, the association had been loading fine.

It appears that the second issue mentioned in #547 has already been fixed in PR #589.
