### PR TITLE
postgres: Fix inability to create model with known int primary key

### DIFF
--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -60,7 +60,11 @@ func (p *postgresql) Create(s store, model *Model, cols columns.Columns) error {
 	}
 	switch keyType {
 	case "int", "int64":
-		cols.Remove(model.IDField())
+		if model.ID() == 0 {
+			cols.Remove(model.IDField())
+		} else {
+			cols.Cols[model.IDField()].Writeable = true
+		}
 		w := cols.Writeable()
 		var query string
 		if len(w.Cols) > 0 {

--- a/executors_test.go
+++ b/executors_test.go
@@ -1579,3 +1579,19 @@ func Test_TruncateAll(t *testing.T) {
 		r.Equal(count, ctx)
 	})
 }
+
+func Test_Create_Single_Set_ID(t *testing.T) {
+	if PDB == nil {
+		t.Skip("skipping integration tests")
+	}
+	r := require.New(t)
+	validationLogs = []string{}
+	transaction(func(tx *Connection) {
+		singleID := &SingleID{
+			ID: 123456,
+		}
+		err := tx.Create(singleID)
+		r.NoError(err)
+		r.Equal(123456, singleID.ID)
+	})
+}


### PR DESCRIPTION
Problem and a partial fix already described in #586 