### PR TITLE
Fixing Goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,7 +89,8 @@ changelog:
 
 brews:
   -
-    github:
+    name: 'pop'
+    tap:
       owner: gobuffalo
       name: homebrew-tap
     homepage: "https://gobuffalo.io/docs/db/getting-started"


### PR DESCRIPTION
It seems Goreleaser yml has changed for the action we use. This PR changes our iml to meet the expected syntax and  have our releases back to work.