### PR TITLE
Make sqlx.DB field public.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -120,7 +120,7 @@ func (c *Connection) Open() error {
 	if details.Unsafe {
 		db = db.Unsafe()
 	}
-	c.Store = &dB{db}
+	c.Store = &Database{db}
 
 	if d, ok := c.Dialect.(afterOpenable); ok {
 		err = d.AfterOpen(c)

--- a/db.go
+++ b/db.go
@@ -7,26 +7,30 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-type dB struct {
+type Database struct {
 	*sqlx.DB
 }
 
-func (db *dB) TransactionContext(ctx context.Context) (*Tx, error) {
+func (db *Database) TransactionContext(ctx context.Context) (*Tx, error) {
 	return newTX(ctx, db, nil)
 }
 
-func (db *dB) Transaction() (*Tx, error) {
+func (db *Database) Transaction() (*Tx, error) {
 	return newTX(context.Background(), db, nil)
 }
 
-func (db *dB) TransactionContextOptions(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
+func (db *Database) TransactionContextOptions(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 	return newTX(ctx, db, opts)
 }
 
-func (db *dB) Rollback() error {
+func (db *Database) Rollback() error {
 	return nil
 }
 
-func (db *dB) Commit() error {
+func (db *Database) Commit() error {
 	return nil
+}
+
+func (db *Database) Database() *Database {
+	return db
 }

--- a/store.go
+++ b/store.go
@@ -15,6 +15,7 @@ type store interface {
 	NamedExec(string, interface{}) (sql.Result, error)
 	Exec(string, ...interface{}) (sql.Result, error)
 	PrepareNamed(string) (*sqlx.NamedStmt, error)
+	Database() *Database
 	Transaction() (*Tx, error)
 	Rollback() error
 	Commit() error

--- a/tx.go
+++ b/tx.go
@@ -17,14 +17,16 @@ func init() {
 // Tx stores a transaction with an ID to keep track.
 type Tx struct {
 	ID int
+	DB *Database
 	*sqlx.Tx
 }
 
-func newTX(ctx context.Context, db *dB, opts *sql.TxOptions) (*Tx, error) {
+func newTX(ctx context.Context, db *Database, opts *sql.TxOptions) (*Tx, error) {
 	t := &Tx{
 		ID: rand.Int(),
 	}
 	tx, err := db.BeginTxx(ctx, opts)
+	t.DB = db
 	t.Tx = tx
 	return t, errors.Wrap(err, "could not create new transaction")
 }
@@ -50,4 +52,8 @@ func (tx *Tx) Transaction() (*Tx, error) {
 // Close does nothing. This is defined so it implements the `Store` interface.
 func (tx *Tx) Close() error {
 	return nil
+}
+
+func (tx *Tx) Database() *Database {
+	return tx.DB
 }


### PR DESCRIPTION
This proposal makes it possible to expose the `sqlx.DB` field to Pop users.

While I understand that it might be desirable to abstract the underlying database layer from users of the Pop API, this design choice makes it difficult for Pop applications to be compatible with existing software that uses `sqlx.DB` directly.

By exposing the `sqlx.DB`, larger applications can migrate to Pop using a phased approach.

Other alternatives would be creating a separate, duplicate `sqlx.DB` outside of Pop, or allowing an existing `sqlx.DB` to be passed into Pop when creating a connection (rather than using `database.yml`, for example).