### PR TITLE
Added connection maximum idle time configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     container:
-      image: bepsays/ci-goreleaser:1.13-4
+      image: bepsays/ci-goreleaser:1.15.1
     steps:
       - name: Checkout Code
         uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
       - name: Checkout Code
         uses: actions/checkout@v1
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
       - name: Checkout Code
         uses: actions/checkout@v1
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
       - name: Checkout Code
         uses: actions/checkout@v1
@@ -139,7 +139,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
       - name: Checkout Code
         uses: actions/checkout@v1
@@ -181,7 +181,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/connection.go
+++ b/connection.go
@@ -117,6 +117,9 @@ func (c *Connection) Open() error {
 	if details.ConnMaxLifetime > 0 {
 		db.SetConnMaxLifetime(details.ConnMaxLifetime)
 	}
+	if details.ConnMaxIdleTime > 0 {
+		db.SetConnMaxIdleTime(details.ConnMaxIdleTime)
+	}
 	if details.Unsafe {
 		db = db.Unsafe()
 	}

--- a/connection.go
+++ b/connection.go
@@ -5,9 +5,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/gobuffalo/pop/v5/internal/defaults"
 	"github.com/gobuffalo/pop/v5/internal/randx"
-	"github.com/pkg/errors"
 )
 
 // Connections contains all available connections

--- a/connection_details.go
+++ b/connection_details.go
@@ -44,6 +44,8 @@ type ConnectionDetails struct {
 	IdlePool int
 	// Defaults to 0 "unlimited". See https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime
 	ConnMaxLifetime time.Duration
+	// Defaults to 0 "unlimited". See https://golang.org/pkg/database/sql/#DB.SetConnMaxIdleTime
+	ConnMaxIdleTime time.Duration
 	// Defaults to `false`. See https://godoc.org/github.com/jmoiron/sqlx#DB.Unsafe
 	Unsafe  bool
 	Options map[string]string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gobuffalo/pop/v5
 
-go 1.13
+go 1.15
 
 replace github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.14.0
 


### PR DESCRIPTION
This PR add the possibility to configure the connection maximum idle time (https://golang.org/pkg/database/sql/#DB.SetConnMaxIdleTime).

More information on the associated issue
Close #632

Edit: I hadn't noticed but pop is targeting go1.13 however my changes require at least go1.15 (which is why the tests fail). I'm not sure what's the best strategy here, I could add a build constraint but it would require to duplicate the code.