### PR TITLE
EagerPreload: Added fix/tests for has_many with pointer foreign key

### DIFF
--- a/pop_test.go
+++ b/pop_test.go
@@ -150,6 +150,8 @@ type Taxi struct {
 	UpdatedAt   time.Time `db:"updated_at"`
 }
 
+type Taxis []Taxi
+
 // Validate gets run every time you call a "Validate*" (ValidateAndSave, ValidateAndCreate, ValidateAndUpdate) method.
 // This method is not required and may be deleted.
 func (b *Book) Validate(tx *Connection) (*validate.Errors, error) {
@@ -180,6 +182,7 @@ type Address struct {
 	HouseNumber int       `db:"house_number"`
 	CreatedAt   time.Time `db:"created_at"`
 	UpdatedAt   time.Time `db:"updated_at"`
+	TaxisToHere Taxis     `has_many:"taxis" fk_id:"to_address_id" order_by:"created_at asc"`
 }
 
 type Addresses []Address

--- a/preload_associations.go
+++ b/preload_associations.go
@@ -271,8 +271,9 @@ func preloadHasMany(tx *Connection, asoc *AssociationMetaInfo, mmi *ModelMetaInf
 		modelAssociationField := mmi.mapper.FieldByName(mvalue, asoc.Name)
 		for i := 0; i < slice.Elem().Len(); i++ {
 			asocValue := slice.Elem().Index(i)
-			if mmi.mapper.FieldByName(mvalue, "ID").Interface() == mmi.mapper.FieldByName(asocValue, foreignField.Path).Interface() ||
-				reflect.DeepEqual(mmi.mapper.FieldByName(mvalue, "ID"), mmi.mapper.FieldByName(asocValue, foreignField.Path)) {
+			valueField := reflect.Indirect(mmi.mapper.FieldByName(asocValue, foreignField.Path))
+			if mmi.mapper.FieldByName(mvalue, "ID").Interface() == valueField.Interface() ||
+				reflect.DeepEqual(mmi.mapper.FieldByName(mvalue, "ID"), valueField) {
 
 				switch {
 				case modelAssociationField.Kind() == reflect.Slice || modelAssociationField.Kind() == reflect.Array:


### PR DESCRIPTION
This PR attempts to fix #646 where `EagerPreload` does not load a `has_many` association with a pointer-based foreign key, but `Eager` works fine with the same association/pointer.