### PR TITLE
Adding changes in #335 by @kayslay to handle transaction panic

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -150,6 +150,14 @@ func (c *Connection) Transaction(fn func(tx *Connection) error) error {
 		if err != nil {
 			return err
 		}
+
+		defer func() {
+			if err := recover(); err != nil {
+				cn.TX.Rollback()
+				err = errors.Errorf("panic err %v", err)
+			}
+		}()
+
 		err = fn(cn)
 		if err != nil {
 			dberr = cn.TX.Rollback()


### PR DESCRIPTION
Original comment was:

> Handle panic that comes from the fn func(tx *Connection) parameter.
> 
> Whenever a panic occurs in a Connection.Transaction the TX.Rollback or TX.Commit is not called after the panic has been recovered. Any call to the Connection.Transaction would block forever.

Thanks @kayslay

cc @stanislas-m @kayslay