### PR TITLE
Introduce ClearSelect() and ReSelect() to pop.Query

### DIFF
--- a/finders.go
+++ b/finders.go
@@ -393,3 +393,22 @@ func (q *Query) Select(fields ...string) *Query {
 	}
 	return q
 }
+
+// ReSelect returns a new query with the select columns redefined
+// q = c.Select("field1", "field2")
+// q = q.ReSelect("field1").All(&model)
+// => SELECT field1 FROM models
+func (q *Query) ReSelect(fields ...string) *Query {
+	tmpQuery := Q(q.Connection)
+	q.Clone(tmpQuery)
+	q = q.ClearSelect()
+	return q.Select(fields...)
+}
+
+// ClearSelect clears the selected columns in the query
+// q = c.Select("field1", "field2").ClearSelect().Select("field1").All(&model)
+// => SELECT field1 FROM models
+func (q *Query) ClearSelect(fields ...string) *Query {
+	q.addColumns = []string{}
+	return q
+}


### PR DESCRIPTION
These functions allow the caller to clear the Select columns (addColumns) of a query and create a clone of the query with the select columns redefined. This is useful if you pass a pop.Query to something that needs to select just a subset of fields (or new set of fields) without having to rebuild the entire query.

A common example is to take a full column select and create an ID-only variant:
```
q := db.Select("things.*").Where(....)
callThingWithQ(q)

func callThingWithQ() {

  // Get the IDs
 qIDs  := db.ReSelect("things.id")
}
```

Let me know if you have any questions or prefer a different syntax. The main thing missing from pop was a way to clear addColumns externally.