### PR TITLE
fix: log model values everywhere

### DIFF
--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -81,7 +81,7 @@ func (p *cockroach) Create(s store, model *Model, cols columns.Columns) error {
 		} else {
 			query = fmt.Sprintf("INSERT INTO %s DEFAULT VALUES returning %s", p.Quote(model.TableName()), model.IDField())
 		}
-		log(logging.SQL, query)
+		log(logging.SQL, query, model.Value)
 		stmt, err := s.PrepareNamed(query)
 		if err != nil {
 			return err

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -53,7 +53,7 @@ func genericCreate(s store, model *Model, cols columns.Columns, quoter quotable)
 		cols.Remove(model.IDField())
 		w := cols.Writeable()
 		query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quoter.Quote(model.TableName()), w.QuotedString(quoter), w.SymbolizedString())
-		log(logging.SQL, query)
+		log(logging.SQL, query, model.Value)
 		res, err := s.NamedExec(query, model.Value)
 		if err != nil {
 			return err
@@ -81,7 +81,7 @@ func genericCreate(s store, model *Model, cols columns.Columns, quoter quotable)
 		w := cols.Writeable()
 		w.Add(model.IDField())
 		query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quoter.Quote(model.TableName()), w.QuotedString(quoter), w.SymbolizedString())
-		log(logging.SQL, query)
+		log(logging.SQL, query, model.Value)
 		stmt, err := s.PrepareNamed(query)
 		if err != nil {
 			return err

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -68,7 +68,7 @@ func (p *postgresql) Create(s store, model *Model, cols columns.Columns) error {
 		} else {
 			query = fmt.Sprintf("INSERT INTO %s DEFAULT VALUES returning %s", p.Quote(model.TableName()), model.IDField())
 		}
-		log(logging.SQL, query)
+		log(logging.SQL, query, model.Value)
 		stmt, err := s.PrepareNamed(query)
 		if err != nil {
 			return err

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -82,7 +82,7 @@ func (m *sqlite) Create(s store, model *Model, cols columns.Columns) error {
 			} else {
 				query = fmt.Sprintf("INSERT INTO %s DEFAULT VALUES", m.Quote(model.TableName()))
 			}
-			log(logging.SQL, query)
+			log(logging.SQL, query, model.Value)
 			res, err := s.NamedExec(query, model.Value)
 			if err != nil {
 				return err


### PR DESCRIPTION
Some SQL logs were missing the values as argument. This adds the SQL arguments to the ones missing yet.