### PR TITLE
fix: sorting of down migrations

### DIFF
--- a/file_migrator.go
+++ b/file_migrator.go
@@ -81,7 +81,15 @@ func (fm *FileMigrator) findMigrations(runner func(mf Migration, tx *Connection)
 				Type:      match.Type,
 				Runner:    runner,
 			}
-			fm.Migrations[mf.Direction] = append(fm.Migrations[mf.Direction], mf)
+			switch mf.Direction {
+			case "up":
+				fm.UpMigrations.Migrations = append(fm.UpMigrations.Migrations, mf)
+			case "down":
+				fm.DownMigrations.Migrations = append(fm.DownMigrations.Migrations, mf)
+			default:
+				// the regex only matches `(up|down)` for direction, so a panic here is appropriate
+				panic("got unknown migration direction " + mf.Direction)
+			}
 		}
 		return nil
 	})

--- a/migration_box.go
+++ b/migration_box.go
@@ -75,7 +75,15 @@ func (fm *MigrationBox) findMigrations(runner func(f packd.File) func(mf Migrati
 			Type:      match.Type,
 			Runner:    runner(f),
 		}
-		fm.Migrations[mf.Direction] = append(fm.Migrations[mf.Direction], mf)
+		switch mf.Direction {
+		case "up":
+			fm.UpMigrations.Migrations = append(fm.UpMigrations.Migrations, mf)
+		case "down":
+			fm.DownMigrations.Migrations = append(fm.DownMigrations.Migrations, mf)
+		default:
+			// the regex only matches `(up|down)` for direction, so a panic here is appropriate
+			panic("got unknown migration direction " + mf.Direction)
+		}
 		return nil
 	})
 }

--- a/migration_box_test.go
+++ b/migration_box_test.go
@@ -32,11 +32,11 @@ func Test_MigrationBox(t *testing.T) {
 
 		b, err := NewMigrationBox(packr.New("./testdata/migrations/multiple", "./testdata/migrations/multiple"), PDB)
 		r.NoError(err)
-		r.Equal(4, len(b.Migrations["up"]))
-		r.Equal("mysql", b.Migrations["up"][0].DBType)
-		r.Equal("postgres", b.Migrations["up"][1].DBType)
-		r.Equal("sqlite3", b.Migrations["up"][2].DBType)
-		r.Equal("all", b.Migrations["up"][3].DBType)
+		r.Equal(4, len(b.UpMigrations.Migrations))
+		r.Equal("mysql", b.UpMigrations.Migrations[0].DBType)
+		r.Equal("postgres", b.UpMigrations.Migrations[1].DBType)
+		r.Equal("sqlite3", b.UpMigrations.Migrations[2].DBType)
+		r.Equal("all", b.UpMigrations.Migrations[3].DBType)
 	})
 
 	t.Run("ignores clutter files", func(t *testing.T) {
@@ -45,7 +45,7 @@ func Test_MigrationBox(t *testing.T) {
 
 		b, err := NewMigrationBox(packr.New("./testdata/migrations/cluttered", "./testdata/migrations/cluttered"), PDB)
 		r.NoError(err)
-		r.Equal(1, len(b.Migrations["up"]))
+		r.Equal(1, len(b.UpMigrations.Migrations))
 		r.Equal(1, len(*logs))
 		r.Equal(logging.Warn, (*logs)[0].lvl)
 		r.Contains((*logs)[0].s, "ignoring file")
@@ -58,7 +58,7 @@ func Test_MigrationBox(t *testing.T) {
 
 		b, err := NewMigrationBox(packr.New("./testdata/migrations/unsupported_dialect", "./testdata/migrations/unsupported_dialect"), PDB)
 		r.NoError(err)
-		r.Equal(0, len(b.Migrations["up"]))
+		r.Equal(0, len(b.UpMigrations.Migrations))
 		r.Equal(1, len(*logs))
 		r.Equal(logging.Warn, (*logs)[0].lvl)
 		r.Contains((*logs)[0].s, "ignoring migration")

--- a/migration_info.go
+++ b/migration_info.go
@@ -36,14 +36,6 @@ func (mfs Migrations) Len() int {
 	return len(mfs)
 }
 
-func (mfs Migrations) Less(i, j int) bool {
-	if mfs[i].Version == mfs[j].Version {
-		// force "all" to the back
-		return mfs[i].DBType != "all"
-	}
-	return mfs[i].Version < mfs[j].Version
-}
-
 func (mfs Migrations) Swap(i, j int) {
 	mfs[i], mfs[j] = mfs[j], mfs[i]
 }
@@ -56,4 +48,29 @@ func (mfs *Migrations) Filter(f func(mf Migration) bool) {
 		}
 	}
 	*mfs = vsf
+}
+
+type (
+	UpMigrations struct {
+		Migrations
+	}
+	DownMigrations struct {
+		Migrations
+	}
+)
+
+func (mfs UpMigrations) Less(i, j int) bool {
+	if mfs.Migrations[i].Version == mfs.Migrations[j].Version {
+		// force "all" to the back
+		return mfs.Migrations[i].DBType != "all"
+	}
+	return mfs.Migrations[i].Version < mfs.Migrations[j].Version
+}
+
+func (mfs DownMigrations) Less(i, j int) bool {
+	if mfs.Migrations[i].Version == mfs.Migrations[j].Version {
+		// force "all" to the back
+		return mfs.Migrations[i].DBType != "all"
+	}
+	return mfs.Migrations[i].Version > mfs.Migrations[j].Version
 }

--- a/migration_info_test.go
+++ b/migration_info_test.go
@@ -8,43 +8,65 @@ import (
 )
 
 func TestSortingMigrations(t *testing.T) {
-	t.Run("case=enforces precedence for specific migrations", func(t *testing.T) {
-		migrations := Migrations{
-			{
-				Version: "1",
-				DBType:  "all",
-			},
-			{
-				Version: "1",
-				DBType:  "postgres",
-			},
-			{
-				Version: "2",
-				DBType:  "cockroach",
-			},
-			{
-				Version: "2",
-				DBType:  "all",
-			},
-			{
-				Version: "3",
-				DBType:  "all",
-			},
-			{
-				Version: "3",
-				DBType:  "mysql",
-			},
-		}
+	examples := Migrations{
+		{
+			Version: "1",
+			DBType:  "all",
+		},
+		{
+			Version: "1",
+			DBType:  "postgres",
+		},
+		{
+			Version: "2",
+			DBType:  "cockroach",
+		},
+		{
+			Version: "2",
+			DBType:  "all",
+		},
+		{
+			Version: "3",
+			DBType:  "all",
+		},
+		{
+			Version: "3",
+			DBType:  "mysql",
+		},
+	}
+
+	t.Run("case=enforces precedence for specific up migrations", func(t *testing.T) {
+		migrations := make(Migrations, len(examples))
+		copy(migrations, examples)
+
 		expectedOrder := Migrations{
-			migrations[1],
-			migrations[0],
-			migrations[2],
-			migrations[3],
-			migrations[5],
-			migrations[4],
+			examples[1],
+			examples[0],
+			examples[2],
+			examples[3],
+			examples[5],
+			examples[4],
 		}
 
-		sort.Sort(migrations)
+		sort.Sort(UpMigrations{migrations})
+
+		assert.Equal(t, expectedOrder, migrations)
+	})
+
+	t.Run("case=enforces precedence for specific down migrations", func(t *testing.T) {
+		migrations := make(Migrations, len(examples))
+		copy(migrations, examples)
+
+		expectedOrder := Migrations{
+			examples[5],
+			examples[4],
+			examples[2],
+			examples[3],
+			examples[1],
+			examples[0],
+		}
+
+		sort.Sort(DownMigrations{migrations})
 
 		assert.Equal(t, expectedOrder, migrations)
 	})


### PR DESCRIPTION
This is related to #533.
Basically, just reversing the up migration order does not work, as that puts "all" migrations before specific ones. Therefore, I added implemented the proper `Less` function for down migrations explicitly.