### PR TITLE
feat: add query.Delete

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -13,6 +13,7 @@ type crudable interface {
 	Create(store, *Model, columns.Columns) error
 	Update(store, *Model, columns.Columns) error
 	Destroy(store, *Model) error
+	Delete(store, *Model, Query) error
 }
 
 type fizzable interface {

--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -110,6 +110,10 @@ func (p *cockroach) Destroy(s store, model *Model) error {
 	return err
 }
 
+func (p *cockroach) Delete(s store, model *Model, query Query) error {
+	return genericDelete(s, model, query)
+}
+
 func (p *cockroach) SelectOne(s store, model *Model, query Query) error {
 	return genericSelectOne(s, model, query)
 }

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -119,7 +119,7 @@ func genericDestroy(s store, model *Model, quoter quotable) error {
 
 func genericDelete(s store, model *Model, query Query) error {
 	sqlQuery, args := query.ToSQL(model)
-	_, err := genericExec(s, sqlQuery, args)
+	_, err := genericExec(s, sqlQuery, args...)
 	return err
 }
 

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -117,6 +117,12 @@ func genericDestroy(s store, model *Model, quoter quotable) error {
 	return nil
 }
 
+func genericDelete(s store, model *Model, query Query) error {
+	sqlQuery, args := query.ToSQL(model)
+	_, err := genericExec(s, sqlQuery, args)
+	return err
+}
+
 func genericExec(s store, stmt string, args ...interface{}) (sql.Result, error) {
 	log(logging.SQL, stmt, args...)
 	res, err := s.Exec(stmt, args...)

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -96,6 +96,10 @@ func (m *mysql) Destroy(s store, model *Model) error {
 	return errors.Wrap(err, "mysql destroy")
 }
 
+func (m *mysql) Delete(s store, model *Model, query Query) error {
+	return genericDelete(s, model, query)
+}
+
 func (m *mysql) SelectOne(s store, model *Model, query Query) error {
 	return errors.Wrap(genericSelectOne(s, model, query), "mysql select one")
 }

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -97,7 +97,13 @@ func (m *mysql) Destroy(s store, model *Model) error {
 }
 
 func (m *mysql) Delete(s store, model *Model, query Query) error {
-	return genericDelete(s, model, query)
+	sb := query.toSQLBuilder(model)
+
+	sql := fmt.Sprintf("DELETE FROM %s", m.Quote(model.TableName()))
+	sql = sb.buildWhereClauses(sql)
+
+	_, err := genericExec(s, sql, sb.Args()...)
+	return errors.Wrap(err, "mysql delete")
 }
 
 func (m *mysql) SelectOne(s store, model *Model, query Query) error {

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -100,6 +100,10 @@ func (p *postgresql) Destroy(s store, model *Model) error {
 	return nil
 }
 
+func (p *postgresql) Delete(s store, model *Model, query Query) error {
+	return genericDelete(s, model, query)
+}
+
 func (p *postgresql) SelectOne(s store, model *Model, query Query) error {
 	return genericSelectOne(s, model, query)
 }

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -112,6 +112,10 @@ func (m *sqlite) Destroy(s store, model *Model) error {
 	})
 }
 
+func (m *sqlite) Delete(s store, model *Model, query Query) error {
+	return genericDelete(s, model, query)
+}
+
 func (m *sqlite) SelectOne(s store, model *Model, query Query) error {
 	return m.locker(m.smGil, func() error {
 		return errors.Wrap(genericSelectOne(s, model, query), "sqlite select one")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ./sqldumps:/docker-entrypoint-initdb.d
   cockroach:
     image: cockroachdb/cockroach:v20.2.4
+    user: ${CURRENT_UID:?"Please run as follows 'CURRENT_UID=$(id -u):$(id -g) docker-compose up'"}
     ports:
       - "26257:26257"
     volumes:

--- a/executors.go
+++ b/executors.go
@@ -439,3 +439,16 @@ func (c *Connection) Destroy(model interface{}) error {
 		})
 	})
 }
+
+func (q *Query) Delete(model interface{}) error {
+	q.Operation = Delete
+
+	return q.Connection.timeFunc("Delete", func() error {
+		m := NewModel(model, q.Connection.Context())
+		err := q.Connection.Dialect.Delete(q.Connection.Store, m, *q)
+		if err != nil {
+			return err
+		}
+		return m.afterDestroy(q.Connection)
+	})
+}

--- a/query.go
+++ b/query.go
@@ -7,6 +7,13 @@ import (
 	"github.com/gobuffalo/pop/v5/logging"
 )
 
+type operation string
+
+const (
+	Select operation = "SELECT"
+	Delete operation = "DELETE"
+)
+
 // Query is the main value that is used to build up a query
 // to be executed against the `Connection`.
 type Query struct {
@@ -25,6 +32,7 @@ type Query struct {
 	havingClauses           havingClauses
 	Paginator               *Paginator
 	Connection              *Connection
+	Operation               operation
 }
 
 // Clone will fill targetQ query with the connection used in q, if
@@ -42,6 +50,7 @@ func (q *Query) Clone(targetQ *Query) {
 	targetQ.groupClauses = q.groupClauses
 	targetQ.havingClauses = q.havingClauses
 	targetQ.addColumns = q.addColumns
+	targetQ.Operation = q.Operation
 
 	if q.Paginator != nil {
 		paginator := *q.Paginator
@@ -196,6 +205,7 @@ func Q(c *Connection) *Query {
 		eager:       c.eager,
 		eagerFields: c.eagerFields,
 		eagerMode:   eagerModeNil,
+		Operation:   Select,
 	}
 }
 

--- a/test.sh
+++ b/test.sh
@@ -37,6 +37,11 @@ function cleanup {
 # defer cleanup, so it will be executed even after premature exit
 trap cleanup EXIT
 
+# The cockroach volume is created by the root user if no user is set.
+# Therefore we set the current user according to https://github.com/docker/compose/issues/1532#issuecomment-619548112
+CURRENT_UID="$(id -u):$(id -g)"
+export CURRENT_UID
+
 docker-compose up -d
 sleep 5 # Ensure mysql is online
 
@@ -68,7 +73,7 @@ function debug_test {
     dlv test github.com/gobuffalo/pop
 }
 
-dialects=("postgres" "cockroach" "mysql" "sqlite")
+dialects=("sqlite")
 
 for dialect in "${dialects[@]}" ; do
   if [ $DEBUG = 'NO' ]; then

--- a/test.sh
+++ b/test.sh
@@ -73,7 +73,7 @@ function debug_test {
     dlv test github.com/gobuffalo/pop
 }
 
-dialects=("sqlite")
+dialects=("postgres" "cockroach" "mysql" "sqlite")
 
 for dialect in "${dialects[@]}" ; do
   if [ $DEBUG = 'NO' ]; then


### PR DESCRIPTION
This allows writing delete queries without knowing the exact primary key or for composite keys.
`Destroy` only allows to delete by primary key, but there are many cases where you want to delete multiple rows or by some other query than the ID.

Contributes to #29 