### PR TITLE
hotfix: format generated file and mod tidy for them.

### DIFF
--- a/soda/cmd/generate/model_cmd.go
+++ b/soda/cmd/generate/model_cmd.go
@@ -2,10 +2,13 @@ package generate
 
 import (
 	"context"
+	"os"
+	"os/exec"
 
 	"github.com/gobuffalo/attrs"
 	"github.com/gobuffalo/fizz"
 	"github.com/gobuffalo/genny/v2"
+	"github.com/gobuffalo/genny/v2/gogen"
 	"github.com/gobuffalo/logger"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/pop/v6/genny/fizz/ctable"
@@ -67,8 +70,22 @@ var ModelCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
 		run.With(g)
+
+		// format generated go files
+		pwd, _ := os.Getwd()
+		g, err = gogen.Fmt(pwd)
+		if err != nil {
+			return err
+		}
+		run.With(g)
+
+		// generated modules may have new dependencies
+		if _, err := os.Stat("go.mod"); err == nil {
+			g = genny.New()
+			g.Command(exec.Command("go", "mod", "tidy"))
+			run.With(g)
+		}
 
 		// Mount migrations generator
 		if !modelCmdConfig.SkipMigration {


### PR DESCRIPTION
Format generated `model.go` file and run `go mod tidy` for the file.
Implemented mod tidy with genny's runner since `genny/gogen/gomods` was removed in genny/v2.

updates: https://github.com/gobuffalo/cli/issues/65