### PR TITLE
Replace removed  command

### DIFF
--- a/soda/cmd/migrate.go
+++ b/soda/cmd/migrate.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"os"
 	"errors"
+	"os"
 
 	"github.com/gobuffalo/pop/v6"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
The  command has been removed from the CLI. This patch introduces a new mechanism to reliably dump the SQL schema for CockroachDB.