### PR TITLE
feat: support embedded struct fields

### DIFF
--- a/associations/associations_for_struct.go
+++ b/associations/associations_for_struct.go
@@ -72,6 +72,16 @@ func ForStruct(s interface{}, fields ...string) (Associations, error) {
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 
+		// inline embedded field
+		if f.Anonymous {
+			innerAssociations, err := ForStruct(v.Field(i).Interface(), fields...)
+			if err != nil {
+				return nil, err
+			}
+			associations = append(associations, innerAssociations...)
+			continue
+		}
+
 		// ignores those fields not included in fields list.
 		if len(fields) > 0 && fieldIgnoredIn(fields, f.Name) {
 			continue

--- a/executors_test.go
+++ b/executors_test.go
@@ -533,6 +533,33 @@ func Test_Create_Non_PK_ID(t *testing.T) {
 	})
 }
 
+func Test_Embedded_Struct(t *testing.T) {
+	if PDB == nil {
+		t.Skip("skipping integration tests")
+	}
+	transaction(func(tx *Connection) {
+		r := require.New(t)
+
+		entry := &EmbeddingStruct{
+			InnerStruct:     InnerStruct{},
+			AdditionalField: "I am also important!",
+		}
+		r.NoError(tx.Create(entry))
+
+		var actual EmbeddingStruct
+		r.NoError(tx.Find(&actual, entry.ID))
+		r.Equal(entry.AdditionalField, actual.AdditionalField)
+
+		entry.AdditionalField = entry.AdditionalField + " updated"
+		r.NoError(tx.Update(entry))
+
+		r.NoError(tx.Find(&actual, entry.ID))
+		r.Equal(entry.AdditionalField, actual.AdditionalField)
+
+		r.NoError(tx.Destroy(entry))
+	})
+}
+
 func Test_Eager_Create_Has_Many(t *testing.T) {
 	if PDB == nil {
 		t.Skip("skipping integration tests")

--- a/pop_test.go
+++ b/pop_test.go
@@ -476,3 +476,14 @@ type NonStandardID struct {
 	ID          int    `db:"pk"`
 	OutfacingID string `db:"id"`
 }
+
+type InnerStruct struct {
+	ID        int       `db:"id"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+type EmbeddingStruct struct {
+	InnerStruct
+	AdditionalField string `db:"additional_field"`
+}

--- a/test.sh
+++ b/test.sh
@@ -58,7 +58,7 @@ function test {
   ./tsoda create -e $SODA_DIALECT -c ./database.yml -p ./testdata/migrations
   ./tsoda migrate -e $SODA_DIALECT -c ./database.yml -p ./testdata/migrations
   echo "Test..."
-  go test -race -tags sqlite $VERBOSE ./... -count=1
+  go test -race -tags sqlite $VERBOSE -count=1 ./...
 }
 
 function debug_test {

--- a/testdata/migrations/20220214113659_embedded_struct.down.fizz
+++ b/testdata/migrations/20220214113659_embedded_struct.down.fizz
@@ -1,0 +1,1 @@
+drop_table("embedding_structs")

--- a/testdata/migrations/20220214113659_embedded_struct.up.fizz
+++ b/testdata/migrations/20220214113659_embedded_struct.up.fizz
@@ -1,0 +1,7 @@
+create_table("embedding_structs") {
+ t.Column("id", "int", { "primary": true })
+
+ t.Column("additional_field", "string", {})
+
+ t.Timestamps()
+}


### PR DESCRIPTION
Currently, embedded structs are not flattened during model column generation. The underlying libraries (reflect and sqlx) however support it already. Therefore, the change was not huge.
Please point me where to add more tests if needed.

closes #582