### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -169,10 +169,11 @@ func (m *sqlite) CreateDB() error {
 	if err != nil {
 		return fmt.Errorf("could not create SQLite database '%s': %w", m.ConnectionDetails.Database, err)
 	}
-	_, err = os.Create(m.ConnectionDetails.Database)
+	f, err := os.Create(m.ConnectionDetails.Database)
 	if err != nil {
 		return fmt.Errorf("could not create SQLite database '%s': %w", m.ConnectionDetails.Database, err)
 	}
+	_ = f.Close()
 
 	log(logging.Info, "created database '%s'", m.ConnectionDetails.Database)
 	return nil

--- a/dialect_sqlite_test.go
+++ b/dialect_sqlite_test.go
@@ -4,8 +4,6 @@ package pop
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -133,10 +131,8 @@ func Test_ConnectionDetails_Finalize_SQLite_OverrideOptions_Synonym_Path(t *test
 
 func Test_ConnectionDetails_FinalizeOSPath(t *testing.T) {
 	r := require.New(t)
-	d, err := ioutil.TempDir("", "")
-	r.NoError(err)
+	d := t.TempDir()
 	p := filepath.Join(d, "testdb.sqlite")
-	defer os.RemoveAll(p)
 	cd := &ConnectionDetails{
 		Dialect:  "sqlite",
 		Database: p,
@@ -148,10 +144,8 @@ func Test_ConnectionDetails_FinalizeOSPath(t *testing.T) {
 
 func TestSqlite_CreateDB(t *testing.T) {
 	r := require.New(t)
-	dir, err := ioutil.TempDir("", "")
-	r.NoError(err)
+	dir := t.TempDir()
 	p := filepath.Join(dir, "testdb.sqlite")
-	defer os.RemoveAll(p)
 	cd := &ConnectionDetails{
 		Dialect:  "sqlite",
 		Database: p,

--- a/soda/cmd/generate/config_cmd_test.go
+++ b/soda/cmd/generate/config_cmd_test.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,9 +12,7 @@ func Test_ConfigCmd_NoArg(t *testing.T) {
 	c := ConfigCmd
 	c.SetArgs([]string{})
 
-	tdir, err := ioutil.TempDir("", "testapp")
-	r.NoError(err)
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	pwd, err := os.Getwd()
 	r.NoError(err)

--- a/soda/cmd/generate/fizz_cmd_test.go
+++ b/soda/cmd/generate/fizz_cmd_test.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,9 +12,7 @@ func Test_FizzCmd_NoArg(t *testing.T) {
 	c := FizzCmd
 	c.SetArgs([]string{})
 
-	tdir, err := ioutil.TempDir("", "testapp")
-	r.NoError(err)
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	pwd, err := os.Getwd()
 	r.NoError(err)

--- a/soda/cmd/generate/model_cmd_test.go
+++ b/soda/cmd/generate/model_cmd_test.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,9 +13,7 @@ func Test_ModelCmd_NoArg(t *testing.T) {
 	c := ModelCmd
 	c.SetArgs([]string{})
 
-	tdir, err := ioutil.TempDir("", "testapp")
-	r.NoError(err)
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	pwd, err := os.Getwd()
 	r.NoError(err)
@@ -32,9 +29,7 @@ func Test_ModelCmd_NameOnly(t *testing.T) {
 	c := ModelCmd
 	c.SetArgs([]string{"users"})
 
-	tdir, err := ioutil.TempDir("", "testapp")
-	r.NoError(err)
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	pwd, err := os.Getwd()
 	r.NoError(err)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir