### PR TITLE
fix: associations for embedded fields

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
   mysql:
@@ -25,7 +25,7 @@ services:
       - ./sqldumps:/docker-entrypoint-initdb.d
   cockroach:
     image: cockroachdb/cockroach:v20.2.4
-    user: ${CURRENT_UID:?"Please run as follows 'CURRENT_UID=$(id -u):$(id -g) docker-compose up'"}
+    user: ${CURRENT_UID:?"Please run as follows 'CURRENT_UID=$$(id -u):$$(id -g) docker-compose up'"}
     ports:
       - "26257:26257"
     volumes:

--- a/executors_test.go
+++ b/executors_test.go
@@ -1245,11 +1245,17 @@ func Test_Eager_Embedded_Struct(t *testing.T) {
 		}
 
 		type User struct {
-			ID        int          `db:"id"`
-			UserName  string       `db:"user_name"`
-			Name      nulls.String `db:"name"`
-			CreatedAt time.Time    `db:"created_at"`
-			UpdatedAt time.Time    `db:"updated_at"`
+			ID        int           `db:"id"`
+			UserName  string        `db:"user_name"`
+			Email     string        `db:"email"`
+			Name      nulls.String  `db:"name"`
+			Alive     nulls.Bool    `db:"alive"`
+			CreatedAt time.Time     `db:"created_at"`
+			UpdatedAt time.Time     `db:"updated_at"`
+			BirthDate nulls.Time    `db:"birth_date"`
+			Bio       nulls.String  `db:"bio"`
+			Price     nulls.Float64 `db:"price"`
+			FullName  nulls.String  `db:"full_name" select:"name as full_name"`
 
 			AssocFields
 		}
@@ -1311,11 +1317,17 @@ func Test_Eager_Embedded_Ptr_Struct(t *testing.T) {
 		}
 
 		type User struct {
-			ID        int          `db:"id"`
-			UserName  string       `db:"user_name"`
-			Name      nulls.String `db:"name"`
-			CreatedAt time.Time    `db:"created_at"`
-			UpdatedAt time.Time    `db:"updated_at"`
+			ID        int           `db:"id"`
+			UserName  string        `db:"user_name"`
+			Email     string        `db:"email"`
+			Name      nulls.String  `db:"name"`
+			Alive     nulls.Bool    `db:"alive"`
+			CreatedAt time.Time     `db:"created_at"`
+			UpdatedAt time.Time     `db:"updated_at"`
+			BirthDate nulls.Time    `db:"birth_date"`
+			Bio       nulls.String  `db:"bio"`
+			Price     nulls.Float64 `db:"price"`
+			FullName  nulls.String  `db:"full_name" select:"name as full_name"`
 
 			*AssocFields
 		}


### PR DESCRIPTION
This fixes some edge cases not covered in #691. Before these changes, associations in embedded structs would cause all kinds of panics in `reflect`.