### PR TITLE
feature: supporting sqlite :memory: and mode=memory on the sqlite driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ testdata/migrations/schema.sql
 vendor/
 .env
 .release-env
+.vscode
 
 # test data
 cockroach-data/


### PR DESCRIPTION
This PR allows to use `:memory:` and `mode=memory` in the `database.yml` configuration file to use SQLite in memory. This is something that comes very handy when dealing with SQLite based applications.

While on this I noticed there is the chance to support module-root relative routes in the `database.yml` and improve development experience for sqlite.