### PR TITLE
fix: add lock to registering instrumented drivers

### DIFF
--- a/connection_instrumented.go
+++ b/connection_instrumented.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"sync"
 
 	mysqld "github.com/go-sql-driver/mysql"
 	"github.com/gobuffalo/pop/v6/logging"
@@ -13,6 +14,8 @@ import (
 )
 
 const instrumentedDriverName = "instrumented-sql-driver"
+
+var sqlDriverLock = sync.Mutex{}
 
 func instrumentDriver(deets *ConnectionDetails, defaultDriverName string) (driverName, dialect string, err error) {
 	driverName = defaultDriverName
@@ -55,6 +58,9 @@ func instrumentDriver(deets *ConnectionDetails, defaultDriverName string) (drive
 		}
 		newDriverName = instrumentedDriverName + "-" + nameSQLite3
 	}
+
+	sqlDriverLock.Lock()
+	defer sqlDriverLock.Unlock()
 
 	var found bool
 	for _, n := range sql.Drivers() {


### PR DESCRIPTION
Fixes
```
panic: sql: Register called twice for driver instrumented-sql-driver-sqlite3 [recovered]
        panic: sql: Register called twice for driver instrumented-sql-driver-sqlite3

goroutine 15 [running]:
testing.tRunner.func1.2({0x1837d40, 0xc000473b70})
        /usr/lib/go/src/testing/testing.go:1389 +0x366
testing.tRunner.func1()
        /usr/lib/go/src/testing/testing.go:1392 +0x5d2
panic({0x1837d40, 0xc000473b70})
        /usr/lib/go/src/runtime/panic.go:844 +0x258
database/sql.Register({0x1a43574, 0x1f}, {0x1de6f60?, 0xc00046fb00})
        /usr/lib/go/src/database/sql/sql.go:51 +0x1d4
github.com/gobuffalo/pop/v6.instrumentDriver(0xc0002e63c0, {0x1a1f3bd, 0x7})
        /home/patrik/git/go/pkg/mod/github.com/gobuffalo/pop/v6@v6.0.1/connection_instrumented.go:68 +0x3e5
github.com/gobuffalo/pop/v6.openPotentiallyInstrumentedConnection({0x1df80b0, 0xc00000f7b8}, {0xc000182780, 0x5b})
        /home/patrik/git/go/pkg/mod/github.com/gobuffalo/pop/v6@v6.0.1/connection_instrumented.go:81 +0x9a
github.com/gobuffalo/pop/v6.(*Connection).Open(0xc000455500)
        /home/patrik/git/go/pkg/mod/github.com/gobuffalo/pop/v6@v6.0.1/connection.go:112 +0x11a
```

This problem occurred during parallel tests.

The race condition happened because the reading of the drivers and the registration of the not-found driver can have some delay, during which another go routine could already have registered the driver. Because the registration is happening as a side-effect, this cannot be fixed by the client.