### PR TITLE
fix: make disableEager not trigger the race detector

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -241,8 +241,13 @@ func (c *Connection) Q() *Query {
 
 // disableEager disables eager mode for current connection.
 func (c *Connection) disableEager() {
-	c.eager = false
-	c.eagerFields = []string{}
+	// The check technically is not required, because (*Connection).Eager() creates a (shallow) copy.
+	// When not reusing eager connections, this should be safe.
+	// However, this write triggers the go race detector.
+	if c.eager {
+		c.eager = false
+		c.eagerFields = []string{}
+	}
 }
 
 // TruncateAll truncates all data from the datasource

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "3306:3306"
   postgres:
-    image: postgres:9.6
+    image: postgres:10.21
     environment:
       - POSTGRES_DB=pop_test
       - POSTGRES_USER=postgres

--- a/executors_test.go
+++ b/executors_test.go
@@ -1,6 +1,7 @@
 package pop
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -531,6 +532,19 @@ func Test_Create_Non_PK_ID(t *testing.T) {
 		r.Equal(count+1, ctx)
 		r.NotZero(entry.ID)
 	})
+}
+
+func Test_Create_Parallel(t *testing.T) {
+	if PDB == nil {
+		t.Skip("skipping integration tests")
+	}
+	for i := 0; i < 5; i++ {
+		i := i
+		t.Run(fmt.Sprintf("case=%d", i), func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, PDB.Create(&CrookedColour{Name: fmt.Sprintf("Singer %d", i)}))
+		})
+	}
 }
 
 func Test_Embedded_Struct(t *testing.T) {


### PR DESCRIPTION
After a bit of code search I figured that the race detection mentioned in #723 is kind of a false positive. Adding this check ensures the race detector is not triggered.