### PR TITLE
removed mysqldump option `--column-statistics` to make it compatible with 5.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
+      - name: Setup MySQL environment
+        run: |
+          mysqldump --version
+          echo $HOME
+          echo -e "[mysqldump]\ncolumn-statistics=0" > $HOME/.my.cnf
+
       - name: Build and run soda
         env:
           SODA_DIALECT: "mysql"

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -192,10 +192,9 @@ func (m *mysql) FizzTranslator() fizz.Translator {
 
 func (m *mysql) DumpSchema(w io.Writer) error {
 	deets := m.Details()
-	// Github CI is currently using mysql:5.7 but the mysqldump version doesn't seem to match
-	cmd := exec.Command("mysqldump", "--column-statistics=0", "-d", "-h", deets.Host, "-P", deets.Port, "-u", deets.User, fmt.Sprintf("--password=%s", deets.Password), deets.Database)
+	cmd := exec.Command("mysqldump", "-d", "-h", deets.Host, "-P", deets.Port, "-u", deets.User, fmt.Sprintf("--password=%s", deets.Password), deets.Database)
 	if deets.Port == "socket" {
-		cmd = exec.Command("mysqldump", "--column-statistics=0", "-d", "-S", deets.Host, "-u", deets.User, fmt.Sprintf("--password=%s", deets.Password), deets.Database)
+		cmd = exec.Command("mysqldump", "-d", "-S", deets.Host, "-u", deets.User, fmt.Sprintf("--password=%s", deets.Password), deets.Database)
 	}
 	return genericDumpSchema(deets, cmd, w)
 }


### PR DESCRIPTION
PR #639 added an option `--column-statistics` for `mysqldump` but the option is new and is not supported by MySQL 5.7 (MySQL 5.7 is the oldest supported version) but it made the other users hard to work with. (see comments in #640)

see also: https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_column-statistics


fixes #640