### PR TITLE
fix Connection.Close() to reset the store

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -145,6 +145,7 @@ func (c *Connection) Close() error {
 	if err := c.Store.Close(); err != nil {
 		return fmt.Errorf("couldn't close connection: %w", err)
 	}
+	c.Store = nil
 	return nil
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -28,6 +28,21 @@ func Test_Connection_SimpleFlow(t *testing.T) {
 	r.NoError(err)
 }
 
+func Test_Connection_Open_Close_Reopen(t *testing.T) {
+	r := require.New(t)
+
+	c, err := NewConnection(&ConnectionDetails{
+		URL: "sqlite://file::memory:?_fk=true",
+	})
+	r.NoError(err)
+
+	for i := 0; i < 2; i++ {
+		r.NoError(c.Open())
+		r.NoError(c.Transaction(func(c *Connection) error { return nil }))
+		r.NoError(c.Close())
+	}
+}
+
 func Test_Connection_Open_NoDialect(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
As reported in #510, the `Connection.Close()` just closes the connection to the database but did not update the status of `Connection` so it could not be reused with `Open()`. 

This PR makes the method to reset `Store` so `Open()` can understand the status of the `Connection`. Also, added a test case for this issue.

fixes #510