### PR TITLE
made default logger to print output to stderr instead of stdout

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,8 +25,6 @@ var lookupPaths = []string{"", "./config", "/config", "../", "../config", "../..
 var ConfigName = "database.yml"
 
 func init() {
-	SetLogger(defaultLogger)
-
 	ap := os.Getenv("APP_PATH")
 	if ap != "" {
 		_ = AddLookupPaths(ap)

--- a/logger.go
+++ b/logger.go
@@ -9,18 +9,20 @@ import (
 	"github.com/gobuffalo/pop/v6/logging"
 )
 
-type logger func(lvl logging.Level, s string, args ...interface{})
-
 // Debug mode, to toggle verbose log traces
 var Debug = false
 
 // Color mode, to toggle colored logs
 var Color = true
 
-var log logger
+// SetLogger overrides the default logger.
+func SetLogger(logger func(level logging.Level, s string, args ...interface{})) {
+	log = logger
+}
 
-var defaultStdLogger = stdlog.New(os.Stdout, "[POP] ", stdlog.LstdFlags)
-var defaultLogger = func(lvl logging.Level, s string, args ...interface{}) {
+var defaultStdLogger = stdlog.New(os.Stderr, "[POP] ", stdlog.LstdFlags)
+
+var log = func(lvl logging.Level, s string, args ...interface{}) {
 	if !Debug && lvl <= logging.Debug {
 		return
 	}
@@ -47,12 +49,4 @@ var defaultLogger = func(lvl logging.Level, s string, args ...interface{}) {
 		s = color.YellowString(s)
 	}
 	defaultStdLogger.Println(s)
-}
-
-// SetLogger overrides the default logger.
-//
-// The logger must implement the following interface:
-// type logger func(lvl logging.Level, s string, args ...interface{})
-func SetLogger(l logger) {
-	log = l
 }


### PR DESCRIPTION
The log should not be printed to the standard output. Standard output is for application.

fixes #768
related to #621, #622