### PR TITLE
made the 'version' column primary key to fix #659

### DIFF
--- a/schema_migrations.go
+++ b/schema_migrations.go
@@ -1,3 +1,4 @@
+//go:build !appengine
 // +build !appengine
 
 package pop
@@ -9,7 +10,7 @@ import (
 )
 
 func newSchemaMigrations(name string) fizz.Table {
-	return fizz.Table{
+	tab := fizz.Table{
 		Name: name,
 		Columns: []fizz.Column{
 			{
@@ -24,4 +25,9 @@ func newSchemaMigrations(name string) fizz.Table {
 			{Name: fmt.Sprintf("%s_version_idx", name), Columns: []string{"version"}, Unique: true},
 		},
 	}
+	// this is for https://github.com/gobuffalo/pop/issues/659.
+	// primary key is not necessary for the migration table but it looks like
+	// some database engine versions requires it for index.
+	tab.PrimaryKey("version")
+	return tab
 }


### PR DESCRIPTION
Made the 'version' column the primary key to fix #659.

The schema table does not strongly require a primary key itself, but having PK could be better, and the column `version` is actually a defacto primary key.

In the future, it could be better to consider #561 with it too.


fixes #659