### PR TITLE
fixed concurrent map write issue on ConnectionDetails.Options (#577)

### DIFF
--- a/connection_details.go
+++ b/connection_details.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gobuffalo/pop/v6/internal/defaults"
@@ -46,8 +47,10 @@ type ConnectionDetails struct {
 	// Defaults to 0 "unlimited". See https://golang.org/pkg/database/sql/#DB.SetConnMaxIdleTime
 	ConnMaxIdleTime time.Duration
 	// Defaults to `false`. See https://godoc.org/github.com/jmoiron/sqlx#DB.Unsafe
-	Unsafe  bool
-	Options map[string]string
+	Unsafe bool
+	// Options stores Connection Details options
+	Options     map[string]string
+	optionsLock *sync.Mutex
 	// Query string encoded options from URL. Example: "sslmode=disable"
 	RawOptions string
 	// UseInstrumentedDriver if set to true uses a wrapper for the underlying driver which exposes tracing
@@ -189,4 +192,35 @@ func (cd *ConnectionDetails) OptionsString(s string) string {
 		}
 	}
 	return strings.TrimLeft(s, "&")
+}
+
+// option returns the value stored in ConnecitonDetails.Options with key k.
+func (cd *ConnectionDetails) option(k string) string {
+	if cd.Options == nil {
+		return ""
+	}
+	return defaults.String(cd.Options[k], "")
+}
+
+// setOptionWithDefault stores given value v in ConnectionDetails.Options
+// with key k. If v is empty string, it stores def instead.
+// It uses locking mechanism to make the operation safe.
+func (cd *ConnectionDetails) setOptionWithDefault(k, v, def string) {
+	cd.setOption(k, defaults.String(v, def))
+}
+
+// setOption stores given value v in ConnectionDetails.Options with key k.
+// It uses locking mechanism to make the operation safe.
+func (cd *ConnectionDetails) setOption(k, v string) {
+	if cd.optionsLock == nil {
+		cd.optionsLock = &sync.Mutex{}
+	}
+
+	cd.optionsLock.Lock()
+	if cd.Options == nil { // prevent panic
+		cd.Options = make(map[string]string)
+	}
+
+	cd.Options[k] = v
+	cd.optionsLock.Unlock()
 }

--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -210,7 +210,7 @@ func (p *cockroach) DumpSchema(w io.Writer) error {
 	cmd := exec.Command("cockroach", "sql", "-e", "SHOW CREATE ALL TABLES", "-d", p.Details().Database, "--format", "raw")
 
 	c := p.ConnectionDetails
-	if defaults.String(c.Options["sslmode"], "disable") == "disable" || strings.Contains(c.RawOptions, "sslmode=disable") {
+	if defaults.String(c.option("sslmode"), "disable") == "disable" || strings.Contains(c.RawOptions, "sslmode=disable") {
 		cmd.Args = append(cmd.Args, "--insecure")
 	}
 	return cockroachDumpSchema(p.Details(), cmd, w)
@@ -302,13 +302,13 @@ func newCockroach(deets *ConnectionDetails) (dialect, error) {
 		translateCache: map[string]string{},
 		mu:             sync.Mutex{},
 	}
-	d.info.client = deets.Options["application_name"]
+	d.info.client = deets.option("application_name")
 	return d, nil
 }
 
 func finalizerCockroach(cd *ConnectionDetails) {
 	appName := filepath.Base(os.Args[0])
-	cd.Options["application_name"] = defaults.String(cd.Options["application_name"], appName)
+	cd.setOptionWithDefault("application_name", cd.option("application_name"), appName)
 	cd.Port = defaults.String(cd.Port, portCockroach)
 	if cd.URL != "" {
 		cd.URL = "postgres://" + trimCockroachPrefix(cd.URL)

--- a/dialect_postgresql.go
+++ b/dialect_postgresql.go
@@ -239,12 +239,12 @@ func urlParserPostgreSQL(cd *ConnectionDetails) error {
 	options := []string{"fallback_application_name"}
 	for i := range options {
 		if opt, ok := conf.RuntimeParams[options[i]]; ok {
-			cd.Options[options[i]] = opt
+			cd.setOption(options[i], opt)
 		}
 	}
 
 	if conf.TLSConfig == nil {
-		cd.Options["sslmode"] = "disable"
+		cd.setOption("sslmode", "disable")
 	}
 
 	return nil


### PR DESCRIPTION
Indeed, the map `ConnectionDetails.Options` is not protected on write accesses. This PR adds a setter and getter for the map, and the setter uses a mutex lock to protect them. However, the CD operations only happen when the connection is defined and configured so I am not sure how they are accessed concurrently. :thinking: 

fixes #577