### PR TITLE
prevent empty query to be executed

### DIFF
--- a/executors.go
+++ b/executors.go
@@ -20,10 +20,16 @@ func (c *Connection) Reload(model interface{}) error {
 	})
 }
 
+// TODO: consider merging the following two methods.
+
 // Exec runs the given query.
 func (q *Query) Exec() error {
 	return q.Connection.timeFunc("Exec", func() error {
 		sql, args := q.ToSQL(nil)
+		if sql == "" {
+			return fmt.Errorf("empty query")
+		}
+
 		log(logging.SQL, sql, args...)
 		_, err := q.Connection.Store.Exec(sql, args...)
 		return err
@@ -36,6 +42,10 @@ func (q *Query) ExecWithCount() (int, error) {
 	count := int64(0)
 	return int(count), q.Connection.timeFunc("Exec", func() error {
 		sql, args := q.ToSQL(nil)
+		if sql == "" {
+			return fmt.Errorf("empty query")
+		}
+
 		log(logging.SQL, sql, args...)
 		result, err := q.Connection.Store.Exec(sql, args...)
 		if err != nil {

--- a/query.go
+++ b/query.go
@@ -213,6 +213,10 @@ func Q(c *Connection) *Query {
 // from the `Model` passed in.
 func (q Query) ToSQL(model *Model, addColumns ...string) (string, []interface{}) {
 	sb := q.toSQLBuilder(model, addColumns...)
+	// nil model is allowed only when if RawSQL is provided.
+	if model == nil && (q.RawSQL == nil || q.RawSQL.Fragment == "") {
+		return "", nil
+	}
 	return sb.String(), sb.Args()
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -386,3 +386,22 @@ func Test_ToSQL_RawQuery(t *testing.T) {
 		a.Equal(args, []interface{}{"random", "query"})
 	})
 }
+
+func Test_RawQuery_Empty(t *testing.T) {
+	Debug = true
+	defer func() { Debug = false }()
+
+	t.Run("EmptyQuery", func(t *testing.T) {
+		r := require.New(t)
+		transaction(func(tx *Connection) {
+			r.Error(tx.Q().Exec())
+		})
+	})
+
+	t.Run("EmptyRawQuery", func(t *testing.T) {
+		r := require.New(t)
+		transaction(func(tx *Connection) {
+			r.Error(tx.RawQuery("").Exec())
+		})
+	})
+}


### PR DESCRIPTION
Empty `Query` should not be executed.

fixes #560