### PR TITLE
prevent unnecessary go routines by limiting them when only the model is `AfterFindable`

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -20,14 +20,17 @@ type AfterEagerFindable interface {
 }
 
 func (m *Model) afterFind(c *Connection, eager bool) error {
-	if x, ok := m.Value.(AfterFindable); ok && !eager {
-		if err := x.AfterFind(c); err != nil {
-			return err
+	if eager {
+		if x, ok := m.Value.(AfterEagerFindable); ok {
+			if err := x.AfterEagerFind(c); err != nil {
+				return err
+			}
 		}
-	}
-	if x, ok := m.Value.(AfterEagerFindable); ok && eager {
-		if err := x.AfterEagerFind(c); err != nil {
-			return err
+	} else {
+		if x, ok := m.Value.(AfterFindable); ok {
+			if err := x.AfterFind(c); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -46,13 +49,17 @@ func (m *Model) afterFind(c *Connection, eager bool) error {
 			wg.Go(func() error {
 				y := rv.Index(i)
 				y = y.Addr()
-				if x, ok := y.Interface().(AfterFindable); ok && !eager {
-					return x.AfterFind(c)
+
+				if eager {
+					if x, ok := y.Interface().(AfterEagerFindable); ok {
+						return x.AfterEagerFind(c)
+					}
+				} else {
+					if x, ok := y.Interface().(AfterFindable); ok {
+						return x.AfterFind(c)
+					}
 				}
 
-				if x, ok := y.Interface().(AfterEagerFindable); ok && eager {
-					return x.AfterEagerFind(c)
-				}
 				return nil
 			})
 		}(i)


### PR DESCRIPTION
### What is being done in this PR?

* readability improvement for exclusive blocks (follow up of #802)
* prevent unnecessary go routines by limiting them when only the model is `AfterFindable` (#799)

### What are the main choices made to get to this solution?

* Deep cascaded if blocks are not beautiful but sometimes easy to read. For this case, the exclusive condition is used for two blocks one by one, so grouping them with one if-else will make it easy to read.
* Unnecessary go routine creation was reported as #799 but did not addressed yet. The issue is reasonable, and also it looks better to read.


closes #799