### PR TITLE
feat: use gen_random_uuid() for CockroachDB INSERTs

### DIFF
--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -88,7 +88,7 @@ func (m *sqlite) Create(c *Connection, model *Model, cols columns.Columns) error
 				query = fmt.Sprintf("INSERT INTO %s DEFAULT VALUES", m.Quote(model.TableName()))
 			}
 			txlog(logging.SQL, c, query, model.Value)
-			res, err := c.Store.NamedExec(query, model.Value)
+			res, err := c.Store.NamedExecContext(model.ctx, query, model.Value)
 			if err != nil {
 				return err
 			}

--- a/executors_test.go
+++ b/executors_test.go
@@ -1405,9 +1405,11 @@ func Test_Create_UUID(t *testing.T) {
 
 		count, _ := tx.Count(&Song{})
 		song := Song{Title: "Automatic Buffalo"}
+		r.Equal(uuid.Nil, song.ID)
 		err := tx.Create(&song)
 		r.NoError(err)
 		r.NotZero(song.ID)
+		r.NotEqual(uuid.Nil, song.ID)
 
 		ctx, _ := tx.Count(&Song{})
 		r.Equal(count+1, ctx)
@@ -1520,10 +1522,13 @@ func Test_UpdateQuery_NoUpdatedAt(t *testing.T) {
 	}
 	transaction(func(tx *Connection) {
 		r := require.New(t)
+		existing, err := PDB.Count(&NonStandardID{}) // from previous test runs
+		r.NoError(err)
+		r.GreaterOrEqual(existing, 0)
 		r.NoError(PDB.Create(&NonStandardID{OutfacingID: "must-change"}))
 		count, err := PDB.Where("true").UpdateQuery(&NonStandardID{OutfacingID: "has-changed"}, "id")
 		r.NoError(err)
-		r.Equal(int64(1), count)
+		r.Equal(int64(existing+1), count)
 		entity := NonStandardID{}
 		r.NoError(PDB.First(&entity))
 		r.Equal("has-changed", entity.OutfacingID)

--- a/model_context_test.go
+++ b/model_context_test.go
@@ -102,6 +102,9 @@ func Test_ModelContext(t *testing.T) {
 	t.Run("cache_busting", func(t *testing.T) {
 		r := require.New(t)
 
+		r.NoError(PDB.WithContext(context.WithValue(context.Background(), "prefix", "a")).Destroy(&ContextTable{ID: "expectedA"}))
+		r.NoError(PDB.WithContext(context.WithValue(context.Background(), "prefix", "b")).Destroy(&ContextTable{ID: "expectedB"}))
+
 		var expectedA, expectedB ContextTable
 		expectedA.ID = "expectedA"
 		expectedB.ID = "expectedB"

--- a/query_test.go
+++ b/query_test.go
@@ -388,9 +388,9 @@ func Test_ToSQL_RawQuery(t *testing.T) {
 }
 
 func Test_RawQuery_Empty(t *testing.T) {
-	Debug = true
-	defer func() { Debug = false }()
-
+	if PDB == nil {
+		t.Skip("skipping integration tests")
+	}
 	t.Run("EmptyQuery", func(t *testing.T) {
 		r := require.New(t)
 		transaction(func(tx *Connection) {

--- a/store.go
+++ b/store.go
@@ -13,6 +13,7 @@ type store interface {
 	Select(interface{}, string, ...interface{}) error
 	Get(interface{}, string, ...interface{}) error
 	NamedExec(string, interface{}) (sql.Result, error)
+	NamedQuery(query string, arg interface{}) (*sqlx.Rows, error)
 	Exec(string, ...interface{}) (sql.Result, error)
 	PrepareNamed(string) (*sqlx.NamedStmt, error)
 	Transaction() (*Tx, error)
@@ -24,6 +25,7 @@ type store interface {
 	SelectContext(context.Context, interface{}, string, ...interface{}) error
 	GetContext(context.Context, interface{}, string, ...interface{}) error
 	NamedExecContext(context.Context, string, interface{}) (sql.Result, error)
+	NamedQueryContext(ctx context.Context, query string, arg interface{}) (*sqlx.Rows, error)
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareNamedContext(context.Context, string) (*sqlx.NamedStmt, error)
 	TransactionContext(context.Context) (*Tx, error)

--- a/tx.go
+++ b/tx.go
@@ -54,3 +54,8 @@ func (tx *Tx) Transaction() (*Tx, error) {
 func (tx *Tx) Close() error {
 	return nil
 }
+
+// Workaround for https://github.com/jmoiron/sqlx/issues/447
+func (tx *Tx) NamedQueryContext(ctx context.Context, query string, arg interface{}) (*sqlx.Rows, error) {
+	return sqlx.NamedQueryContext(ctx, tx, query, arg)
+}


### PR DESCRIPTION
Using the `gen_random_uuid()` builtin can significantly speed up inserts because the primary key uniqueness constraint check is elided.

I've also fixed up code where there was a prepared statement being created for just one query, which is super inefficient.

I'm kinda having trouble running the tests locally, so I'd appreciate a workflow approval too. @aeneasr @sio4 👍 