### PR TITLE
fix: incorrect error handling

### DIFF
--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -2,7 +2,7 @@ package pop
 
 import (
 	"bytes"
-	"errors"
+	"database/sql"
 	"fmt"
 	"io"
 	"net/url"
@@ -90,11 +90,17 @@ func (p *cockroach) Create(c *Connection, model *Model, cols columns.Columns) er
 		}
 		defer rows.Close()
 		if !rows.Next() {
-			return errors.New("named insert: no rows")
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("named insert: next: %w", err)
+			}
+			return fmt.Errorf("named insert: %w", sql.ErrNoRows)
 		}
 		var id interface{}
 		if err := rows.Scan(&id); err != nil {
 			return fmt.Errorf("named insert: scan: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("named insert: close: %w", err)
 		}
 		model.setID(id)
 		return nil
@@ -121,11 +127,17 @@ func (p *cockroach) Create(c *Connection, model *Model, cols columns.Columns) er
 		}
 		defer rows.Close()
 		if !rows.Next() {
-			return errors.New("named insert: no rows")
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("named insert: next: %w", err)
+			}
+			return fmt.Errorf("named insert: %w", sql.ErrNoRows)
 		}
 		var id uuid.UUID
 		if err := rows.Scan(&id); err != nil {
 			return fmt.Errorf("named insert: scan: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("named insert: close: %w", err)
 		}
 		model.setID(id)
 		return nil

--- a/preload_associations.go
+++ b/preload_associations.go
@@ -491,6 +491,9 @@ func preloadManyToMany(tx *Connection, asoc *AssociationMetaInfo, mmi *ModelMeta
 			fkids = append(fkids, row[1])
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	q := tx.Q()
 	q.eager = false


### PR DESCRIPTION
Issue: https://github.com/gobuffalo/pop/issues/812

The error handling when using `NamedQueryContext` was incorrect and would fail to return errors to the caller. In `preload_associatons.go` we didn't even close the rows 🤷 .