### PR TITLE
Migrations use Exec() directly vs RawQuery()

### DIFF
--- a/file_migrator.go
+++ b/file_migrator.go
@@ -37,7 +37,7 @@ func NewFileMigrator(path string, c *Connection) (FileMigrator, error) {
 		if content == "" {
 			return nil
 		}
-		err = tx.RawQuery(content).Exec()
+		_, err = tx.Store.Exec(content)
 		if err != nil {
 			return fmt.Errorf("error executing %s, sql: %s: %w", mf.Path, content, err)
 		}

--- a/migration_box.go
+++ b/migration_box.go
@@ -33,7 +33,7 @@ func NewMigrationBox(fsys fs.FS, c *Connection) (MigrationBox, error) {
 			if content == "" {
 				return nil
 			}
-			err = tx.RawQuery(content).Exec()
+			_, err = tx.Store.Exec(content)
 			if err != nil {
 				return fmt.Errorf("error executing %s, sql: %s: %w", mf.Path, content, err)
 			}


### PR DESCRIPTION
This PR solves the problem with migrations replacing all `?` with `$n` (rebinding arguments). Migrations currently use the `RawQuery` method, which replaces all instances of `?` as if it was running a Query. 

An example of where this becomes an issue, was brought up by @viktorkrepak in a Postgres migration:

```sql
CREATE DOMAIN http_url AS varchar(255) CONSTRAINT valid_url CHECK (VALUE ~ '^https?://[^\s/$.\?#][^\s]*$');
```

In this case, the `?` in the regex is replaced by `$1` and `$2`, breaking the regex.

### Related Issues
- [RawQuery rebinds escaped characters](https://github.com/gobuffalo/pop/issues/567)
- [Allow escaping ? to use it for it's Postgres syntax.](https://github.com/gobuffalo/fizz/issues/72)

### Solution
The solution is to call `Exec` on the connection directly vs `RawQuery`. I am not sure of the implications of this change, if there was a built in expectation that queries inside migrations would be rebind arguments. My expectation would be that there should never be queries inside migrations, as migrations are for structure. Queries inside migrations should rather be done in database Seeds.

