### PR TITLE
feat: greatly improve capabilities of delete queries

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -129,7 +129,12 @@ func (m *mysql) Delete(c *Connection, model *Model, query Query) error {
 	sql = sql[len("SELECT"):]
 	sql = "DELETE" + sql
 
-	_, err := genericExec(s, sql, sb.Args()...)
+	// * MySQL does not support table alias for DELETE syntax until 8.0.
+	// * Do not generate SQL manually if they may have `WHERE IN`.
+	// * Spaces are intentionally added to make it easy to see on the log.
+	sql = asRegex.ReplaceAllString(sql, "  ")
+
+	_, err := genericExec(c, sql, sb.Args()...)
 	if err != nil {
 		return fmt.Errorf("mysql delete: %w", err)
 	}
@@ -137,7 +142,7 @@ func (m *mysql) Delete(c *Connection, model *Model, query Query) error {
 }
 
 func (m *mysql) SelectOne(c *Connection, model *Model, query Query) error {
-	if err := genericSelectOne(s, model, query); err != nil {
+	if err := genericSelectOne(c, model, query); err != nil {
 		return fmt.Errorf("mysql select one: %w", err)
 	}
 	return nil

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -122,10 +122,11 @@ func (m *mysql) Delete(c *Connection, model *Model, query Query) error {
 	// However, it supports joins and whatnot on DELETE statements, so we just replace the SELECT
 	// with a DELETE and run the query.
 	sql := sb.buildSelectSQLWithColumns(model.Alias())
-	sql, found := strings.CutPrefix(sql, "SELECT")
-	if !found {
-		panic("expected to get a SELECT query")
+
+	if !strings.HasPrefix(sql, "SELECT") {
+		panic("expected to get a SELECT statement")
 	}
+	sql = sql[len("SELECT"):]
 	sql = "DELETE" + sql
 
 	_, err := genericExec(s, sql, sb.Args()...)

--- a/sql_builder.go
+++ b/sql_builder.go
@@ -130,6 +130,8 @@ func (sq *sqlBuilder) buildDeleteSQL() string {
 
 	sql := fmt.Sprintf("DELETE FROM %s", fc)
 
+	sql = sq.buildJoinClauses(sql)
+
 	sql = sq.buildWhereClauses(sql)
 
 	// paginated delete supported by sqlite and mysql


### PR DESCRIPTION
### What is being done in this PR?

Allow using any `.Join()`, pagination, or whatever capabilities in delete queries.

### What are the main choices made to get to this solution?

Using a select sub-query because it works on any database. The sub-query relies on the assumption that a record only has a unique primary key. Composite keys can cause too many records to be deleted. Similar problems also occur in other parts of the codebase.

### List the manual test cases you've covered before sending this PR:

None, "only" automated tests.