### PR TITLE
feat: add SQLDB() to get the underlying database/sql.(*DB) from a store

### DIFF
--- a/db.go
+++ b/db.go
@@ -11,6 +11,10 @@ type dB struct {
 	*sqlx.DB
 }
 
+func (db *dB) SQLDB() *sql.DB {
+	return db.DB.DB
+}
+
 func (db *dB) TransactionContext(ctx context.Context) (*Tx, error) {
 	return newTX(ctx, db, nil)
 }

--- a/store.go
+++ b/store.go
@@ -21,6 +21,8 @@ type store interface {
 	Commit() error
 	Close() error
 
+	SQLDB() *sql.DB
+
 	// Context versions to wrap with contextStore
 	SelectContext(context.Context, interface{}, string, ...interface{}) error
 	GetContext(context.Context, interface{}, string, ...interface{}) error

--- a/tx.go
+++ b/tx.go
@@ -18,11 +18,13 @@ func init() {
 type Tx struct {
 	ID int
 	*sqlx.Tx
+	db *sql.DB
 }
 
 func newTX(ctx context.Context, db *dB, opts *sql.TxOptions) (*Tx, error) {
 	t := &Tx{
 		ID: rand.Int(),
+		db: db.SQLDB(),
 	}
 	tx, err := db.BeginTxx(ctx, opts)
 	t.Tx = tx
@@ -30,6 +32,10 @@ func newTX(ctx context.Context, db *dB, opts *sql.TxOptions) (*Tx, error) {
 		return nil, fmt.Errorf("could not create new transaction: %w", err)
 	}
 	return t, nil
+}
+
+func (tx *Tx) SQLDB() *sql.DB {
+	return tx.db
 }
 
 // TransactionContext simply returns the current transaction,


### PR DESCRIPTION
### What is being done in this PR?

This allows pop users to obtain a handle to the underlying connection pool (`database/sql.(*DB)`). This is useful, for example, to collect [Prometheus metrics about the status of the connection pool](https://github.com/prometheus/client_golang/blob/d03abf3a31c973a5bc2c2dc698fb41b661a0f0c5/prometheus/collectors/dbstats_collector.go#L40).

### What are the main choices made to get to this solution?

It was the simplest way. The current design of a `pop/(*Tx)` implementing the `store` interface is not optimal, and perhaps a distinctions should be made between a datastore and a transaction (since they are different concepts). But that's a bigger refactoring.

I'd also be open to different implementation strategies.

### List the manual test cases you've covered before sending this PR:

Not sure this needs any tests, really.