### PR TITLE
fix DumpSchema for MySQL and CockroachDB

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -193,7 +193,7 @@ func (m *mysql) FizzTranslator() fizz.Translator {
 
 func (m *mysql) DumpSchema(w io.Writer) error {
 	deets := m.Details()
-	cmd := exec.Command("mysqldump", "-d", "-h", deets.Host, "-P", deets.Port, "-u", deets.User, fmt.Sprintf("--password=%s", deets.Password), deets.Database)
+	cmd := exec.Command("mysqldump", "--protocol", "TCP", "-d", "-h", deets.Host, "-P", deets.Port, "-u", deets.User, fmt.Sprintf("--password=%s", deets.Password), deets.Database)
 	if deets.Port == "socket" {
 		cmd = exec.Command("mysqldump", "-d", "-S", deets.Host, "-u", deets.User, fmt.Sprintf("--password=%s", deets.Password), deets.Database)
 	}


### PR DESCRIPTION
`mysqldump` would previously try to connect through a Unix socket if the host (`-h`) flag was given as `localhost`. This change forces a TCP connection. Connecting through a Unix socket is still supported.

`cockroach sql` would previously always connect on the default port. This change uses the actual DSN information to dump the schema. I've also removed the useless comments from the output.