### PR TITLE
fix(postgres): strip psql backslash commands from pg_dump output

### DIFF
--- a/dialect_common.go
+++ b/dialect_common.go
@@ -188,6 +188,11 @@ func genericLoadSchema(d dialect, r io.Reader) error {
 		return nil
 	}
 
+	// Strip psql backslash commands (e.g. \restrict, \unrestrict) that
+	// may be present in pg_dump output from PostgreSQL 17.6+. These are
+	// psql-only directives and are not valid SQL.
+	contents = stripPsqlBackslashCommands(contents)
+
 	_, err = db.Exec(string(contents))
 	if err != nil {
 		return fmt.Errorf("unable to load schema for %s: %w", deets.Database, err)
@@ -201,9 +206,8 @@ func genericDumpSchema(deets *ConnectionDetails, cmd *exec.Cmd, w io.Writer) err
 	log(logging.SQL, strings.Join(cmd.Args, " "))
 
 	bb := &bytes.Buffer{}
-	mw := io.MultiWriter(w, bb)
 
-	cmd.Stdout = mw
+	cmd.Stdout = bb
 	cmd.Stderr = os.Stderr
 
 	err := cmd.Run()
@@ -216,6 +220,29 @@ func genericDumpSchema(deets *ConnectionDetails, cmd *exec.Cmd, w io.Writer) err
 		return fmt.Errorf("unable to dump schema for %s", deets.Database)
 	}
 
+	// Strip psql backslash commands (e.g. \restrict, \unrestrict) from
+	// pg_dump output so schema.sql stays clean and loadable without psql.
+	clean := stripPsqlBackslashCommands(bb.Bytes())
+	if _, err := w.Write(clean); err != nil {
+		return err
+	}
+
 	log(logging.Info, "dumped schema for %s", deets.Database)
 	return nil
+}
+
+// stripPsqlBackslashCommands removes lines that start with a psql backslash
+// meta-command (e.g. \restrict, \unrestrict). These directives are emitted by
+// pg_dump 17.6+ but are not valid SQL and cause syntax errors when executed
+// directly via db.Exec().
+func stripPsqlBackslashCommands(data []byte) []byte {
+	var buf bytes.Buffer
+	for _, line := range bytes.SplitAfter(data, []byte("\n")) {
+		trimmed := bytes.TrimLeft(line, " \t")
+		if len(trimmed) > 0 && trimmed[0] == '\\' {
+			continue
+		}
+		buf.Write(line)
+	}
+	return buf.Bytes()
 }

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -192,6 +192,11 @@ func genericLoadSchema(d dialect, r io.Reader) error {
 	// may be present in pg_dump output from PostgreSQL 17.6+. These are
 	// psql-only directives and are not valid SQL.
 	contents = stripPsqlBackslashCommands(contents)
+	contents = bytes.TrimSpace(contents)
+	if len(contents) == 0 {
+		log(logging.Info, "schema is empty after stripping psql meta-commands for %s, skipping", deets.Database)
+		return nil
+	}
 
 	_, err = db.Exec(string(contents))
 	if err != nil {
@@ -223,6 +228,9 @@ func genericDumpSchema(deets *ConnectionDetails, cmd *exec.Cmd, w io.Writer) err
 	// Strip psql backslash commands (e.g. \restrict, \unrestrict) from
 	// pg_dump output so schema.sql stays clean and loadable without psql.
 	clean := stripPsqlBackslashCommands(bb.Bytes())
+	if len(bytes.TrimSpace(clean)) == 0 {
+		return fmt.Errorf("unable to dump schema for %s", deets.Database)
+	}
 	if _, err := w.Write(clean); err != nil {
 		return err
 	}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -32,3 +32,61 @@ func Test_genericDumpSchema(t *testing.T) {
 		})
 	}
 }
+
+func Test_genericDumpSchema_stripsBackslashCommands(t *testing.T) {
+	r := require.New(t)
+
+	// Use printf to simulate pg_dump output containing backslash commands
+	cmd := exec.Command("printf", "\\\\restrict abc123\\nCREATE TABLE t (id int);\\n\\\\unrestrict abc123\\n")
+	bb := &bytes.Buffer{}
+	err := genericDumpSchema(&ConnectionDetails{}, cmd, bb)
+	r.NoError(err)
+	r.Equal("CREATE TABLE t (id int);\n", bb.String())
+}
+
+func Test_stripPsqlBackslashCommands(t *testing.T) {
+	table := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:   "no backslash commands",
+			input:  "CREATE TABLE foo (id int);\nINSERT INTO foo VALUES (1);\n",
+			output: "CREATE TABLE foo (id int);\nINSERT INTO foo VALUES (1);\n",
+		},
+		{
+			name:   "restrict and unrestrict",
+			input:  "-- header\n\\restrict abc123\nSET statement_timeout = 0;\n\\unrestrict abc123\n",
+			output: "-- header\nSET statement_timeout = 0;\n",
+		},
+		{
+			name:   "various backslash commands",
+			input:  "\\connect mydb\nCREATE TABLE t (id int);\n\\echo done\n",
+			output: "CREATE TABLE t (id int);\n",
+		},
+		{
+			name:   "empty input",
+			input:  "",
+			output: "",
+		},
+		{
+			name:   "only backslash commands",
+			input:  "\\restrict key1\n\\unrestrict key1\n",
+			output: "",
+		},
+		{
+			name:   "backslash in middle of line is kept",
+			input:  "SELECT E'hello\\nworld';\n",
+			output: "SELECT E'hello\\nworld';\n",
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(st *testing.T) {
+			r := require.New(st)
+			result := stripPsqlBackslashCommands([]byte(tt.input))
+			r.Equal(tt.output, string(result))
+		})
+	}
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -36,8 +36,8 @@ func Test_genericDumpSchema(t *testing.T) {
 func Test_genericDumpSchema_stripsBackslashCommands(t *testing.T) {
 	r := require.New(t)
 
-	// Use printf to simulate pg_dump output containing backslash commands
-	cmd := exec.Command("printf", "\\\\restrict abc123\\nCREATE TABLE t (id int);\\n\\\\unrestrict abc123\\n")
+	// Use printf with %s so backslashes are treated as data, not escape sequences.
+	cmd := exec.Command("printf", "%s", "\\restrict abc123\nCREATE TABLE t (id int);\n\\unrestrict abc123\n")
 	bb := &bytes.Buffer{}
 	err := genericDumpSchema(&ConnectionDetails{}, cmd, bb)
 	r.NoError(err)


### PR DESCRIPTION
PostgreSQL 17.6+ emits psql-only directives like \restrict and \unrestrict in pg_dump output. These cause syntax errors when the schema file is loaded back via db.Exec() since they are not valid SQL. This filters them out during both dump and load so schema files remain portable and loadable without psql.

Closes #860