### PR TITLE
Update CI tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: setup environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.25.x"
           - "1.26.x"
+          - "1.27.x"
 
     services:
       mysql:
-        image: mysql:9.6
+        image: mysql:26.7.0@sha256:4b40b165f348c3a1d959a222bd6c7773503f202554fd140db3de74ed9136b7b8
         env:
           MYSQL_ROOT_PASSWORD: root#
         ports:
@@ -26,9 +26,9 @@ jobs:
         options: --health-cmd "mysqladmin ping -h localhost" --health-interval 5s --health-timeout 5s --health-retries 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -61,12 +61,12 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.25.x"
           - "1.26.x"
+          - "1.27.x"
 
     services:
       postgres:
-        image: postgres:18
+        image: postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres#
@@ -77,9 +77,9 @@ jobs:
         options: --health-cmd pg_isready --health-interval 5s --health-timeout 5s --health-retries 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -106,13 +106,13 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.25.x"
           - "1.26.x"
+          - "1.27.x"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -151,13 +151,13 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.25.x"
           - "1.26.x"
+          - "1.27.x"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -194,17 +194,17 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.25.x"
           - "1.26.x"
+          - "1.27.x"
         os:
           - "macos-latest"
           - "windows-latest"
           - "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
### What is being done in this PR?
This updates the tools and used go version for the CI of pop

### What are the main choices made to get to this solution?
Go 1.25 is not supported any more and the mysql version used in tests can also be upgrade to a more recent version.
